### PR TITLE
Implement dynamic format configuration with UI redesign and i18n support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,89 @@
+# Changelog
+
+All notable changes to this project are documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project uses [Semantic Versioning](https://semver.org/). The version
+number lives in a single place, `package.json`, and is shown live in the app
+footer.
+
+## [1.0.0] - 2026-08-12
+
+First stable release. This version is a full redesign of the app's visual
+layer and a rework of the branch-format system, on top of the local-first,
+no-registration foundation the app already had.
+
+### Added
+- Dynamic branch-format configuration screen: create, edit, clone, delete,
+  and import/export custom formats, with a live preview of the result.
+- Per-field capitalization control (uppercase / lowercase / as-is) and a
+  per-format language profile that drives character sanitization (`ñ`, `ß`,
+  `/`, accents...) consistently across the 6 supported UI languages
+  (en, es, fr, de, it, pt).
+- Explicit default-format selection with a visual indicator, and a
+  visibility switch per format.
+- Built-in formats can now have their visibility and sanitization language
+  edited directly (their name, template, and fields stay locked — clone
+  them to customize those).
+- New reusable UI components: `CustomSelect`, `CustomModal`, and inline SVG
+  icons for the leaf logo, settings, and back-arrow glyphs.
+- Full responsive layout pass (mobile / tablet / desktop) across the whole
+  app, including the new configuration screens.
+- App version displayed in the footer, linking to the matching GitHub
+  release.
+- Full i18n coverage of the configuration screens and built-in format
+  names/labels, which were previously hardcoded in Spanish regardless of
+  the selected UI language.
+
+### Changed
+- Branch name sanitization is no longer an opt-in checklist: dot/space
+  replacement, accent stripping, and special-character removal are always
+  applied, so every generated name is a valid git branch name. Only
+  capitalization remains configurable per field.
+- Native checkboxes/selects in the format editor replaced by the custom,
+  themeable components used across the rest of the app.
+- Header, containers, and spacing reworked to a consistent breakpoint
+  system instead of ad-hoc per-component media queries.
+
+### Fixed
+- Default-format preview no longer falls back to the first format in the
+  list after canceling an edit or deleting a format — it correctly returns
+  to the actual current default.
+- Long branch-name previews wrap at hyphen boundaries instead of breaking
+  mid-word.
+- History list action buttons ("Copy" / "Delete") and the settings button
+  now translate with the rest of the UI instead of always showing English
+  text.
+- Hidden formats can no longer become the app default by clicking their
+  card in the list; they can still be previewed.
+
+### Removed
+- Emoji icons across the UI (inconsistent rendering on Windows/some
+  browsers), replaced with inline SVG icons.
+
+## [0.2.0] - 2026-05-01
+### Added
+- Custom `LangSelector` component with flag icons, replacing the native
+  language `<select>`, with improved keyboard accessibility.
+- Multi-language support groundwork (flag icons, badge terminology).
+
+### Changed
+- CI/deploy workflows updated to Node.js 22.
+
+## [0.1.0] - 2025-10-09
+### Added
+- Full UI redesign unifying the visual style with the author's other
+  local-first tools.
+- Initial i18n support (English/Spanish) and a `docs/` folder documenting
+  the project architecture.
+- Opt-in Google Analytics with a cookie-consent banner.
+- Responsive layout styles for mobile devices.
+
+### Changed
+- License changed from GPL-3.0 to proprietary.
+
+## Initial development - 2024-04-21 to 2025-10-09
+Pre-release history: the original branch-name generator (project ID +
+ticket ID + feature name), branch history stored in `localStorage`, first
+GitHub Pages deployment, and the groundwork later formalized as `Branch`,
+`BranchManager`, and `BranchFormatter`.

--- a/README-es.md
+++ b/README-es.md
@@ -1,4 +1,4 @@
-# Branch Name Formatter 🌿
+# Branch Name Formatter
 
 *Read this in [English](README.md).*
 
@@ -6,30 +6,35 @@ Una herramienta web rápida y local-first diseñada para que los desarrolladores
 
 Todo el procesamiento se realiza localmente en tu navegador web, garantizando un **control total** de tus datos (Local-First). Construido con **Vue 3 (Composition API)** y **TypeScript**.
 
-## ✨ Características Clave
-- **Formateo Instantáneo:** Combina automáticamente el ID del Proyecto, el ID del Ticket y el Nombre del Desarrollo en un nombre de rama limpio.
+## Características Clave
+- **Formatos de Rama Dinámicos:** Incluye tres formatos listos para usar (formato por defecto, GitFlow, Conventional Commits) y permite crear, clonar, editar o borrar los tuyos propios desde la pantalla de Configuración, con previsualización en vivo mientras escribes.
+- **Nombres Siempre Válidos:** El saneado (quitar tildes, espacios, puntos, caracteres especiales, colapsar guiones...) se aplica siempre, así que cada nombre generado es un nombre de rama válido en git. Solo eliges la capitalización por campo (mayúsculas, minúsculas o tal cual).
+- **Saneado Consciente del Idioma:** Cada formato tiene un idioma asociado (los 6 idiomas que soporta la app) que controla cómo se traducen la `/` y caracteres específicos de cada idioma (`ñ`, `ß`...) al nombre de la rama.
 - **Gestión de Historial:** Mantiene un registro de tus últimos 10 nombres generados para un acceso rápido (almacenado localmente).
 - **Procesamiento Local:** Todo sucede en el lado del cliente. Sin almacenamiento ni procesamiento en servidor de tus datos de ramas.
 - **Interfaz:** Diseño limpio, profesional y responsivo con soporte nativo para modo oscuro/claro.
-- **Multilingüe:** Soporte para Inglés y Español.
+- **Multilingüe:** Soporte completo de interfaz para Español, Inglés, Francés, Alemán, Italiano y Portugués — incluyendo el editor de formatos y los propios formatos predefinidos.
 
-## 🛠️ Construido Con
+## Construido Con
 - **Vue.js 3** (Composition API) + **Vite**
 - **TypeScript** para un código robusto y tipado.
 - **Vue-i18n** para soporte multilingüe.
-- **CSS Vanilla** para un rendimiento óptimo y un aspecto profesional "nativo".
+- **CSS Vanilla / SCSS** para un rendimiento óptimo y un aspecto profesional "nativo".
 
-## 📁 Arquitectura del Proyecto
-El proyecto sigue una arquitectura modular separando la lógica de negocio (`BranchManager`) de los componentes de la vista. Puedes consultar los detalles en [`docs/ARCHITECTURE.md`](docs/ARCHITECTURE_ES.md).
+## Arquitectura del Proyecto
+El proyecto separa la lógica de negocio (`BranchManager`, `FormatManager`, `BranchFormatter`) de los componentes de la vista. Consulta [`docs/ARCHITECTURE_ES.md`](docs/ARCHITECTURE_ES.md) para más detalles.
 
-## 🚀 Cómo Ejecutar Localmente
+## Registro de Cambios
+Los cambios notables de cada versión se documentan en [`CHANGELOG.md`](CHANGELOG.md). El número de versión vive en `package.json` y se muestra en directo en el pie de página de la app.
+
+## Cómo Ejecutar Localmente
 ```sh
 npm install
 npm run dev
 ```
 
-## 📄 Licencia
+## Licencia
 Este proyecto es propietario y tiene todos los derechos reservados por Javier Nicolás Pérez Mesa. Se publica exclusivamente con fines de revisión de portafolio, auditoría de código y uso estrictamente personal. Consulta el archivo `LICENSE` para más detalles.
 
 ---
-Hecho con ❤️ 2026.
+Hecho con cuidado, 2026.

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Branch Name Formatter 🌿
+# Branch Name Formatter
 
 *Leer esto en [Español](README-es.md).*
 
@@ -6,30 +6,35 @@ A fast, local-first web tool designed for developers to generate consistent Git 
 
 All processing is done locally in your web browser, ensuring **complete control** of your data (Local-First). Built with **Vue 3 (Composition API)** and **TypeScript**.
 
-## ✨ Key Features
-- **Instant Formatting:** Automatically combines Project ID, Ticket ID, and Feature Name into a clean branch name.
+## Key Features
+- **Dynamic Branch Formats:** Comes with three ready-to-use formats (default app format, GitFlow, Conventional Commits) and lets you create, clone, edit, or delete your own from the Settings screen, with a live preview as you type.
+- **Guaranteed Valid Names:** Sanitization (removing accents, spaces, dots, special characters, collapsing dashes...) is always applied, so every generated name is a valid git branch name. You only choose the capitalization per field (uppercase, lowercase, or as-is).
+- **Language-Aware Sanitization:** Each format has a language profile (matching the app's 6 supported languages) that controls how `/` and language-specific characters (`ñ`, `ß`...) are translated into the branch name.
 - **History Management:** Keeps track of your last 10 generated names for quick access (stored locally).
 - **Local Processing:** Everything happens client-side. No server-side storage or processing of your branch data.
 - **Interface:** Clean, professional, and responsive design with native dark/light mode support.
-- **Multi-language:** Support for English and Spanish.
+- **Multi-language:** Full UI support for English, Spanish, French, German, Italian, and Portuguese — including the format editor and the built-in formats themselves.
 
-## 🛠️ Built With
+## Built With
 - **Vue.js 3** (Composition API) + **Vite**
 - **TypeScript** for robust, typed code.
 - **Vue-i18n** for multi-language support.
-- **Vanilla CSS** for optimal performance and a professional "native" look.
+- **Vanilla CSS / SCSS** for optimal performance and a professional "native" look.
 
-## 📁 Project Architecture
-The project follows a modular architecture separating business logic (`BranchManager`) from the view components. You can check the details in [`docs/ARCHITECTURE.md`](docs/ARCHITECTURE.md).
+## Project Architecture
+The project separates business logic (`BranchManager`, `FormatManager`, `BranchFormatter`) from the view components. See [`docs/ARCHITECTURE.md`](docs/ARCHITECTURE.md) for details.
 
-## 🚀 How to Run Locally
+## Changelog
+Notable changes per version are tracked in [`CHANGELOG.md`](CHANGELOG.md). The version number lives in `package.json` and is shown live in the app footer.
+
+## How to Run Locally
 ```sh
 npm install
 npm run dev
 ```
 
-## 📄 License
+## License
 This project is proprietary and all rights are reserved by Javier Nicolás Pérez Mesa. It is published exclusively for portfolio review, code audit, and personal use. See the `LICENSE` file for details.
 
 ---
-Made with ❤️ 2026.
+Made with care, 2026.

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -2,20 +2,30 @@
 
 The **Branch Name Formatter** is built with a focus on simplicity, maintainability, and privacy.
 
-## 🏗️ Core Structure
+## Core Structure
 
-### 1. Logic Layer (Core)
-- **`Branch.ts`**: The entity representing a branch name. It handles the formatting logic (joining parts with dashes, etc.).
-- **`BranchManager.ts`**: A singleton class that manages the list of branches, handles storage in `localStorage`, and limits the history to 10 records.
+### 1. Logic Layer (`src/core`)
+- **`Branch.ts`** / **`BranchTypes.ts`**: The entity representing a generated branch name and its shared types.
+- **`BranchManager.ts`**: A singleton class that manages the list of generated branches, handles storage in `localStorage` (via `LocalStorageManager`), and limits the history to 10 records.
+- **`FormatTypes.ts`**: Types for the dynamic format system — `BranchFormatTemplate` (a format: id, name, template string, fields, language, visibility), `FieldDefinition` (a field: id, label, type, capitalization), `Capitalization` (`UPPERCASE` / `LOWERCASE` / `AS_IS`), and `LanguageProfile` (the 6 supported languages, used for sanitization rules — independent from the UI language).
+- **`FormatManager.ts`**: A static class that owns the three built-in formats and all persistence for formats in `localStorage` — custom formats, hidden built-in formats, the app's default format id, and language overrides for built-in formats (the only field on a built-in format that can be changed in place).
+- **`BranchFormatter.ts`**: Turns a `BranchFormatTemplate` + raw field values into the final branch name. Sanitization (accents, dots, spaces, special characters, multiple dashes, and the language-specific rules in `LANGUAGE_RULES` for `/` and characters like `ñ`/`ß`) is always applied and is not configurable; only the per-field capitalization is.
 
-### 2. UI Layer (Vue Components)
-- **`App.vue`**: The main container, orchestrating the state and the layout.
-- **`BranchForm.vue`**: Handles user input and emits the data to be processed.
-- **`BranchList.vue` / `BranchItem.vue`**: Display the historical records.
-- **`Footer.vue`**: Static information about the project and license.
+### 2. UI Layer (`src/components`)
+- **`App.vue`**: Root layout — header, hero, and swaps between the main view and the configuration view.
+- **`AppHeader.vue`**: Sticky header with the language selector and the settings toggle.
+- **`AppMainView.vue`** / **`BranchForm.vue`**: The branch generator — renders the fields of the currently selected format dynamically and emits the generated name.
+- **`BranchList.vue`** / **`BranchItem.vue`**: Display the branch history.
+- **`AppConfigurationView.vue`**: The format management screen — lists all formats, lets you pick the app default, and hosts the editor.
+- **`FormatEditor.vue`**: Edits a format. For custom formats, the full form (name, template, language, fields) is editable. For built-in formats, only the visibility switch and the language are editable; the rest is shown read-only (clone the format to fully customize it).
+- **`FormatPreview.vue`**: Renders a live example of a format's output using its own field ids as placeholder values.
+- **`CustomSelect.vue`** / **`CustomModal.vue`**: Shared, themeable replacements for native `<select>` and confirm dialogs, used throughout the app.
+- **`LangSelector.vue`** / **`FlagIcon.vue`**: The UI language switcher.
+- **`Footer.vue`**: Shows the app version (from `package.json`, injected at build time as `__APP_VERSION__`) linked to its GitHub release, plus license/source links.
 
-### 3. Localization
-- **`i18n/`**: Contains the JSON translation files and the configuration for `vue-i18n`.
+### 3. Localization (`src/i18n`)
+- One JSON file per supported language (`en`, `es`, `fr`, `de`, `it`, `pt`), loaded by `vue-i18n` in `index.ts`.
+- Most UI strings are looked up with `$t('namespace.key')`. Built-in format names and field labels are stored as i18n keys (e.g. `formats.gitflow.name`) inside `FormatManager`'s data rather than literal text, so they follow the selected UI language; custom formats store literal text instead. Components that display a format's `name`/field `label` check for a `.` to decide whether to translate it or show it as-is (see `BranchForm.vue`, `AppConfigurationView.vue`).
 
-## 🔒 Privacy & Data
-No data ever leaves the user's browser. We do not use any external APIs or tracking services. Everything is stored in the browser's `localStorage`.
+## Privacy & Data
+No data ever leaves the user's browser. We do not use any external APIs or tracking services beyond an opt-in, cookie-consent-gated analytics script (see `CookieBanner.vue` / `utils/analytics.ts`). Everything else is stored in the browser's `localStorage`.

--- a/docs/ARCHITECTURE_ES.md
+++ b/docs/ARCHITECTURE_ES.md
@@ -2,20 +2,30 @@
 
 El **Branch Name Formatter** está construido con un enfoque en la simplicidad, mantenibilidad y privacidad.
 
-## 🏗️ Estructura Principal
+## Estructura Principal
 
-### 1. Capa de Lógica (Core)
-- **`Branch.ts`**: La entidad que representa el nombre de una rama. Maneja la lógica de formateo (unir partes con guiones, etc.).
-- **`BranchManager.ts`**: Una clase Singleton que gestiona la lista de ramas, maneja el almacenamiento en `localStorage` y limita el historial a 10 registros.
+### 1. Capa de Lógica (`src/core`)
+- **`Branch.ts`** / **`BranchTypes.ts`**: La entidad que representa una rama generada y sus tipos compartidos.
+- **`BranchManager.ts`**: Una clase Singleton que gestiona la lista de ramas generadas, maneja el almacenamiento en `localStorage` (vía `LocalStorageManager`) y limita el historial a 10 registros.
+- **`FormatTypes.ts`**: Tipos del sistema de formatos dinámico — `BranchFormatTemplate` (un formato: id, nombre, plantilla, campos, idioma, visibilidad), `FieldDefinition` (un campo: id, etiqueta, tipo, capitalización), `Capitalization` (`UPPERCASE` / `LOWERCASE` / `AS_IS`) y `LanguageProfile` (los 6 idiomas soportados, usados para el saneado — independiente del idioma de la interfaz).
+- **`FormatManager.ts`**: Una clase estática que define los tres formatos predefinidos y gestiona toda la persistencia de formatos en `localStorage` — formatos personalizados, formatos predefinidos ocultos, el id del formato predeterminado de la app, y los overrides de idioma para formatos predefinidos (el único campo de un formato predefinido que se puede cambiar in situ).
+- **`BranchFormatter.ts`**: Convierte un `BranchFormatTemplate` + los valores de campo en el nombre de rama final. El saneado (tildes, puntos, espacios, caracteres especiales, guiones múltiples, y las reglas específicas por idioma en `LANGUAGE_RULES` para `/` y caracteres como `ñ`/`ß`) se aplica siempre y no es configurable; solo la capitalización por campo lo es.
 
-### 2. Capa de Interfaz (Componentes Vue)
-- **`App.vue`**: El contenedor principal, orquestando el estado y el diseño.
-- **`BranchForm.vue`**: Maneja la entrada del usuario y emite los datos para ser procesados.
-- **`BranchList.vue` / `BranchItem.vue`**: Muestran los registros históricos.
-- **`Footer.vue`**: Información estática sobre el proyecto y la licencia.
+### 2. Capa de Interfaz (`src/components`)
+- **`App.vue`**: Layout raíz — cabecera, hero, y alterna entre la vista principal y la de configuración.
+- **`AppHeader.vue`**: Cabecera fija con el selector de idioma y el botón de configuración.
+- **`AppMainView.vue`** / **`BranchForm.vue`**: El generador de ramas — renderiza dinámicamente los campos del formato seleccionado y emite el nombre generado.
+- **`BranchList.vue`** / **`BranchItem.vue`**: Muestran el historial de ramas.
+- **`AppConfigurationView.vue`**: La pantalla de gestión de formatos — lista todos los formatos, permite elegir el predeterminado de la app, y aloja el editor.
+- **`FormatEditor.vue`**: Edita un formato. Para formatos personalizados, el formulario completo (nombre, plantilla, idioma, campos) es editable. Para formatos predefinidos, solo el interruptor de visibilidad y el idioma son editables; el resto se muestra en solo lectura (clona el formato para personalizarlo del todo).
+- **`FormatPreview.vue`**: Renderiza un ejemplo en vivo del resultado de un formato, usando los propios id de sus campos como valores de ejemplo.
+- **`CustomSelect.vue`** / **`CustomModal.vue`**: Sustitutos compartidos y temáticos de los `<select>` nativos y los diálogos de confirmación, usados en toda la app.
+- **`LangSelector.vue`** / **`FlagIcon.vue`**: El selector de idioma de la interfaz.
+- **`Footer.vue`**: Muestra la versión de la app (desde `package.json`, inyectada en build como `__APP_VERSION__`) enlazada a su release de GitHub, más los enlaces de licencia/código fuente.
 
-### 3. Localización
-- **`i18n/`**: Contiene los archivos JSON de traducción y la configuración para `vue-i18n`.
+### 3. Localización (`src/i18n`)
+- Un archivo JSON por idioma soportado (`en`, `es`, `fr`, `de`, `it`, `pt`), cargados por `vue-i18n` en `index.ts`.
+- La mayoría de textos de la interfaz se resuelven con `$t('namespace.clave')`. Los nombres y etiquetas de campo de los formatos predefinidos se guardan como claves i18n (p. ej. `formats.gitflow.name`) dentro de los datos de `FormatManager`, en vez de texto literal, para que sigan el idioma de interfaz seleccionado; los formatos personalizados guardan texto literal en su lugar. Los componentes que muestran el `name`/`label` de un formato comprueban si contiene un punto para decidir si traducirlo o mostrarlo tal cual (ver `BranchForm.vue`, `AppConfigurationView.vue`).
 
-## 🔒 Privacidad y Datos
-Ningún dato sale del navegador del usuario. No utilizamos APIs externas ni servicios de rastreo. Todo se almacena en el `localStorage` del navegador.
+## Privacidad y Datos
+Ningún dato sale del navegador del usuario. No utilizamos APIs externas ni servicios de rastreo, salvo un script de analítica opt-in sujeto al consentimiento de cookies (ver `CookieBanner.vue` / `utils/analytics.ts`). Todo lo demás se almacena en el `localStorage` del navegador.

--- a/env.d.ts
+++ b/env.d.ts
@@ -1,5 +1,7 @@
 /// <reference types="vite/client" />
 
+declare const __APP_VERSION__: string;
+
 interface Window {
   gtag: (event: string, command: string, params: Record<string, any>) => void;
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "branch-name-formatter",
-  "version": "0.1.0",
+  "version": "1.0.0",
   "private": true,
   "license": "Proprietary",
   "type": "module",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "branch-name-formatter",
-  "version": "0.0.0",
+  "version": "0.1.0",
   "private": true,
   "license": "Proprietary",
   "type": "module",

--- a/src/App.vue
+++ b/src/App.vue
@@ -3,7 +3,7 @@ import { ref } from 'vue'
 
 import Footer from '@/components/Footer.vue'
 import CookieBanner from '@/components/CookieBanner.vue'
-import LangSelector from '@/components/LangSelector.vue'
+import AppHeader from '@/components/AppHeader.vue'
 import { initAnalytics } from '@/utils/analytics'
 
 import AppMainView from '@/components/AppMainView.vue'
@@ -28,20 +28,17 @@ const showConfig = ref(false)
 const toggleConfig = () => {
   showConfig.value = !showConfig.value
 }
+
+const goHome = () => {
+  showConfig.value = false
+}
 </script>
 
 <template>
+  <AppHeader :showConfig="showConfig" :languages="languages" @toggleConfig="toggleConfig" @home="goHome" />
+
   <div class="app-layout">
-    <header class="app-header">
-      <div class="header-top">
-        <button class="btn-secondary config-toggle" @click="toggleConfig">
-          {{ showConfig ? '← Volver' : '⚙️ Configuración' }}
-        </button>
-      </div>
-      <h1>{{ $t('hero.title') }}</h1>
-      <div class="lang-selector-wrapper">
-        <LangSelector v-model="$i18n.locale" :options="languages" />
-      </div>
+    <header class="app-hero container" v-if="!showConfig">
       <p class="subtitle">{{ $t('hero.subtitle') }}</p>
       <div class="badges">
         <span class="badge">{{ $t('hero.badges.auditable') }}</span>
@@ -51,7 +48,7 @@ const toggleConfig = () => {
     </header>
 
     <!-- Simulación de router con v-if -->
-    <AppConfigurationView v-if="showConfig" />
+    <AppConfigurationView v-if="showConfig" @close="toggleConfig" />
     <AppMainView v-else />
 
     <Footer />
@@ -60,37 +57,10 @@ const toggleConfig = () => {
 </template>
 
 <style scoped lang="scss">
-.app-header {
+.app-hero {
   text-align: center;
+  margin-top: 2.5rem;
   margin-bottom: 2.5rem;
-  position: relative;
-}
-
-.header-top {
-  display: flex;
-  justify-content: flex-end;
-  margin-bottom: 1rem;
-}
-
-.config-toggle {
-  display: flex;
-  align-items: center;
-  gap: 0.5rem;
-  font-size: 0.9rem;
-}
-
-.lang-selector-wrapper {
-  display: flex;
-  justify-content: center;
-  margin: 0.75rem 0 1rem 0;
-}
-
-h1 {
-  font-size: 2.5rem;
-  font-weight: 700;
-  letter-spacing: -0.05em;
-  color: var(--text-main);
-  margin: 0;
 }
 
 .subtitle {
@@ -102,12 +72,9 @@ h1 {
   margin-right: auto;
 }
 
-@media (max-width: 600px) {
-  .app-layout {
-    padding: 2rem 1rem;
-  }
-  h1 {
-    font-size: 2rem;
+@media (max-width: vars.$bp-mobile) {
+  .app-hero {
+    margin-top: 1.5rem;
   }
   .subtitle {
     font-size: 1rem;

--- a/src/App.vue
+++ b/src/App.vue
@@ -1,16 +1,13 @@
-<!-- src/App.vue -->
 <script setup lang="ts">
-import { onMounted, ref } from 'vue'
+import { ref } from 'vue'
 
-import BranchForm from '@/components/BranchForm.vue'
-import BranchList from '@/components/BranchList.vue'
 import Footer from '@/components/Footer.vue'
 import CookieBanner from '@/components/CookieBanner.vue'
 import LangSelector from '@/components/LangSelector.vue'
-import { BranchManager } from '@/core/BranchManager'
-import type { BranchFormType } from '@/core/BranchTypes'
-import type { Branch } from '@/core/Branch'
 import { initAnalytics } from '@/utils/analytics'
+
+import AppMainView from '@/components/AppMainView.vue'
+import AppConfigurationView from '@/components/AppConfigurationView.vue'
 
 const languages = [
   { code: 'en', label: 'English' },
@@ -22,45 +19,25 @@ const languages = [
 ]
 
 const handleCookieAccept = () => {
-  const gaId = (import.meta.env.VITE_GA_ID as string) || 'G-XXXXXXXXXX';
-  initAnalytics(gaId);
-};
-
-// --- Original Application Logic ---
-const branchManager = BranchManager.getInstance()
-
-const branches = ref<Branch[]>(branchManager.getBranches())
-const showHistory = ref(false)
-const latestBranch = ref<Branch | null>(null)
-const copied = ref(false)
-
-const copyToClipboard = async (text: string) => {
-  await navigator.clipboard.writeText(text)
-  copied.value = true
-  setTimeout(() => {
-    copied.value = false
-  }, 2000)
+  const gaId = (import.meta.env.VITE_GA_ID as string) || 'G-XXXXXXXXXX'
+  initAnalytics(gaId)
 }
 
-const updateBranches = () => {
-  branches.value = [...branchManager.getBranches()]
-}
+const showConfig = ref(false)
 
-const handleFormSubmit = (formData: BranchFormType) => {
-  branchManager.createBranch(formData)
-  updateBranches()
-  latestBranch.value = branches.value[0] || null
-}
-
-const handleDeleteBranch = (branchId: number) => {
-  branchManager.deleteBranch(branchId)
-  updateBranches()
+const toggleConfig = () => {
+  showConfig.value = !showConfig.value
 }
 </script>
 
 <template>
   <div class="app-layout">
     <header class="app-header">
+      <div class="header-top">
+        <button class="btn-secondary config-toggle" @click="toggleConfig">
+          {{ showConfig ? '← Volver' : '⚙️ Configuración' }}
+        </button>
+      </div>
       <h1>{{ $t('hero.title') }}</h1>
       <div class="lang-selector-wrapper">
         <LangSelector v-model="$i18n.locale" :options="languages" />
@@ -73,33 +50,9 @@ const handleDeleteBranch = (branchId: number) => {
       </div>
     </header>
 
-    <main class="main-content">
-      <div class="converter-box">
-        <BranchForm @submitForm="handleFormSubmit" />
-      </div>
-
-      <div v-if="latestBranch" class="result-section">
-        <h2 class="result-title">{{ $t('result.title') }}</h2>
-        <div class="result-card">
-          <code class="result-code">{{ latestBranch.branchName }}</code>
-          <button class="btn-primary" @click="copyToClipboard(latestBranch.branchName)">
-            {{ copied ? $t('result.copied') : $t('result.copy') }}
-          </button>
-        </div>
-      </div>
-
-      <div class="history-section">
-        <div class="history-header">
-          <button class="btn-secondary toggle-btn" @click="showHistory = !showHistory">
-            {{ showHistory ? $t('history.hide') : $t('history.show') }}
-          </button>
-        </div>
-
-        <div v-if="showHistory" class="history-pane">
-          <BranchList :branches="branches" @deleteBranch="handleDeleteBranch" />
-        </div>
-      </div>
-    </main>
+    <!-- Simulación de router con v-if -->
+    <AppConfigurationView v-if="showConfig" />
+    <AppMainView v-else />
 
     <Footer />
     <CookieBanner @accept="handleCookieAccept" />
@@ -110,6 +63,20 @@ const handleDeleteBranch = (branchId: number) => {
 .app-header {
   text-align: center;
   margin-bottom: 2.5rem;
+  position: relative;
+}
+
+.header-top {
+  display: flex;
+  justify-content: flex-end;
+  margin-bottom: 1rem;
+}
+
+.config-toggle {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  font-size: 0.9rem;
 }
 
 .lang-selector-wrapper {
@@ -139,23 +106,11 @@ h1 {
   .app-layout {
     padding: 2rem 1rem;
   }
-
-
-
   h1 {
     font-size: 2rem;
   }
-
   .subtitle {
     font-size: 1rem;
-  }
-
-  .converter-box {
-    padding: 1.5rem;
-  }
-
-  .result-code {
-    font-size: 1.25rem;
   }
 }
 
@@ -176,69 +131,5 @@ h1 {
   font-weight: 500;
   text-transform: uppercase;
   letter-spacing: 0.05em;
-}
-
-.converter-box {
-  background-color: var(--bg-surface);
-  padding: 2rem;
-  border-radius: 12px;
-  border: 1px solid var(--border-color);
-  margin-bottom: 2rem;
-  box-shadow: 0 4px 6px -1px rgba(0, 0, 0, 0.05);
-}
-
-.result-section {
-  animation: fadeIn 0.3s ease-out;
-  margin-bottom: 3rem;
-}
-
-.result-title {
-  font-size: 0.9rem;
-  font-weight: 600;
-  color: var(--text-muted);
-  margin-bottom: 0.75rem;
-  text-transform: uppercase;
-  letter-spacing: 0.05em;
-  text-align: center;
-}
-
-.result-card {
-  background-color: var(--bg-surface);
-  border: 1px solid var(--border-color);
-  border-radius: 12px;
-  padding: 1.5rem;
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  gap: 1.5rem;
-}
-
-.result-code {
-  font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
-  font-size: 1.5rem;
-  font-weight: 600;
-  color: var(--text-main);
-  word-break: break-all;
-  text-align: center;
-}
-
-.history-section {
-  margin-top: 4rem;
-}
-
-.history-header {
-  display: flex;
-  justify-content: center;
-  margin-bottom: 2rem;
-}
-
-.history-pane {
-  animation: fadeIn 0.3s ease-out;
-}
-
-.separator {
-  margin: 1.5rem 0;
-  border: none;
-  border-top: 1px solid var(--border-color);
 }
 </style>

--- a/src/assets/base.css
+++ b/src/assets/base.css
@@ -53,7 +53,6 @@ body {
   flex-direction: column;
 }
 
-/* Anchos en sincronía con $container-width / $container-width-wide en variables.scss */
 .container {
   max-width: 800px;
   margin: 0 auto;

--- a/src/assets/base.css
+++ b/src/assets/base.css
@@ -39,34 +39,54 @@ body {
   -moz-osx-font-smoothing: grayscale;
 }
 
-.app-layout {
-  max-width: 800px;
-  margin: 0 auto;
-  padding: 3rem 1.5rem;
-  min-height: 100vh;
+#app {
   display: flex;
   flex-direction: column;
+  min-height: 100vh;
+}
+
+.app-layout {
+  width: 100%;
+  padding: 3rem 1.5rem;
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+}
+
+/* Anchos en sincronía con $container-width / $container-width-wide en variables.scss */
+.container {
+  max-width: 800px;
+  margin: 0 auto;
+  width: 100%;
+}
+
+.container-wide {
+  max-width: 960px;
+  margin: 0 auto;
+  width: 100%;
 }
 
 .main-content {
   flex: 1;
 }
 
+/* Padding/tamaño en sincronía con $control-padding-y/x y $control-font-size en variables.scss */
 .input-element {
   background-color: var(--bg-body);
   color: var(--text-main);
   border: 1px solid var(--border-color);
   border-radius: 8px;
-  padding: 1rem;
-  transition: all 0.2s;
-  font-size: 0.9rem;
+  padding: 0.85rem 1rem;
+  transition: all 0.2s ease-in-out;
+  font-size: 0.95rem;
   font-family: inherit;
+  box-shadow: 0 1px 2px rgba(0, 0, 0, 0.05);
 }
 
 .input-element:focus {
   outline: none;
   border-color: var(--accent-color);
-  box-shadow: 0 0 0 2px var(--accent-color-alpha);
+  box-shadow: 0 0 0 3px var(--accent-color-alpha);
 }
 
 .btn-primary {
@@ -74,32 +94,48 @@ body {
   color: var(--bg-body);
   border: none;
   border-radius: 8px;
-  padding: 0.75rem 1.5rem;
+  padding: 0.85rem 1.5rem;
   font-weight: 600;
   cursor: pointer;
-  transition: opacity 0.2s;
+  transition: all 0.2s ease;
+  box-shadow: 0 4px 6px -1px rgba(0, 0, 0, 0.1), 0 2px 4px -1px rgba(0, 0, 0, 0.06);
 }
 
 .btn-primary:hover {
   opacity: 0.9;
+  transform: translateY(-1px);
+  box-shadow: 0 6px 8px -1px rgba(0, 0, 0, 0.15), 0 3px 6px -1px rgba(0, 0, 0, 0.1);
+}
+
+.btn-primary:active {
+  transform: translateY(0);
+  box-shadow: 0 2px 4px -1px rgba(0, 0, 0, 0.1);
 }
 
 .btn-secondary {
   background-color: var(--bg-surface);
   color: var(--text-main);
   border: 1px solid var(--border-color);
-  padding: 0.5rem 1rem;
+  padding: 0.6rem 1.2rem;
   border-radius: 8px;
   font-weight: 600;
   cursor: pointer;
-  transition: background-color 0.2s;
+  transition: all 0.2s ease;
+  box-shadow: 0 1px 2px rgba(0, 0, 0, 0.05);
 }
 
 .btn-secondary:hover {
   background-color: var(--bg-surface-hover);
+  border-color: var(--text-muted);
 }
 
 @keyframes fadeIn {
   from { opacity: 0; transform: translateY(5px); }
   to { opacity: 1; transform: translateY(0); }
+}
+
+@media (max-width: 600px) {
+  .app-layout {
+    padding: 1.5rem 1rem 2rem;
+  }
 }

--- a/src/assets/variables.scss
+++ b/src/assets/variables.scss
@@ -1,9 +1,16 @@
-@use 'sass:color';
+// Breakpoints compartidos
+$bp-mobile: 600px;
+$bp-tablet: 900px;
 
-$color-white: #eee5e9;
-$color-beige: #f3d5b5;
-$color-red: #e24c4b;
-$color-dark-blue: #0e2a3a;
-$color-blue: #08415c;
+// Anchos de contenedor
+$container-width: 800px;
+$container-width-wide: 960px;
 
-// Renombrado a SCSS para compatibilidad moderna
+// Tamaños de control (inputs, selects) — origen único para que no diverjan entre sí
+$control-padding-y: 0.85rem;
+$control-padding-x: 1rem;
+$control-font-size: 0.95rem;
+
+$control-padding-y-sm: 0.5rem;
+$control-padding-x-sm: 0.75rem;
+$control-font-size-sm: 0.9rem;

--- a/src/assets/variables.scss
+++ b/src/assets/variables.scss
@@ -2,9 +2,9 @@
 $bp-mobile: 600px;
 $bp-tablet: 900px;
 
-// Anchos de contenedor
-$container-width: 800px;
-$container-width-wide: 960px;
+// Nota: los anchos de contenedor (.container / .container-wide) viven como
+// valores planos en base.css, que no puede leer variables SCSS. Si cambian
+// aquí, hay que actualizarlos también allí.
 
 // Tamaños de control (inputs, selects) — origen único para que no diverjan entre sí
 $control-padding-y: 0.85rem;

--- a/src/components/AppConfigurationView.vue
+++ b/src/components/AppConfigurationView.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import { ref, onMounted } from 'vue'
+import { useI18n } from 'vue-i18n'
 import { FormatManager } from '@/core/FormatManager'
 import type { BranchFormatTemplate } from '@/core/FormatTypes'
 import FormatPreview from '@/components/FormatPreview.vue'
@@ -8,6 +9,8 @@ import CustomModal from '@/components/CustomModal.vue'
 import ArrowLeftIcon from '@/components/ArrowLeftIcon.vue'
 
 const emit = defineEmits(['close'])
+
+const { t, locale } = useI18n()
 
 const formats = ref<BranchFormatTemplate[]>([])
 const editingFormat = ref<BranchFormatTemplate | null>(null)
@@ -39,9 +42,12 @@ const getPreviewFallback = (): BranchFormatTemplate | null => {
 }
 
 // Al hacer clic en una tarjeta se previsualiza y, a la vez, se marca como
-// el formato predeterminado de la app.
+// el formato predeterminado de la app. Un formato oculto solo se previsualiza:
+// no puede convertirse en predeterminado mientras no esté visible.
 const selectFormat = (format: BranchFormatTemplate) => {
   previewFormat.value = format
+  if (!format.isVisible) return
+
   defaultFormatId.value = format.id
   FormatManager.setDefaultFormatId(format.id)
 }
@@ -52,11 +58,21 @@ const handleEdit = (format: BranchFormatTemplate) => {
 }
 
 const handleClone = (formatId: string) => {
-  const cloned = FormatManager.cloneFormat(formatId)
+  const resolveLabel = (value: string) => value.includes('.') ? t(value) : value
+  const cloned = FormatManager.cloneFormat(formatId, resolveLabel, t('configurator.cloneSuffix'))
   if (cloned) {
     loadFormats()
     handleEdit(cloned)
   }
+}
+
+// Recarga la lista y refresca el formato que se está editando/previsualizando
+// tras un cambio persistido fuera del flujo normal de Guardar (toggles instantáneos).
+const refreshEditingFormat = (id: string) => {
+  loadFormats()
+  const refreshed = formats.value.find(f => f.id === id) || null
+  editingFormat.value = refreshed
+  previewFormat.value = refreshed
 }
 
 const handleToggleVisibilityInEditor = () => {
@@ -71,10 +87,13 @@ const handleToggleVisibilityInEditor = () => {
     FormatManager.setDefaultFormatId(defaultFormatId.value ?? '')
   }
 
-  loadFormats()
-  const refreshed = formats.value.find(f => f.id === id) || null
-  editingFormat.value = refreshed
-  previewFormat.value = refreshed
+  refreshEditingFormat(id)
+}
+
+const handleUpdateLanguageInEditor = (language: BranchFormatTemplate['language']) => {
+  if (!editingFormat.value) return
+  FormatManager.setLanguage(editingFormat.value.id, language)
+  refreshEditingFormat(editingFormat.value.id)
 }
 
 const promptDelete = (formatId: string) => {
@@ -104,14 +123,14 @@ const cancelDelete = () => {
 const startNewFormat = () => {
   const newFormat: BranchFormatTemplate = {
     id: `custom-${Date.now()}`,
-    name: 'Nuevo Formato',
+    name: t('configurator.newFormatName'),
     templateString: '{campo1}-{campo2}',
     isReadonly: false,
     isVisible: true,
-    language: 'es',
+    language: locale.value as BranchFormatTemplate['language'],
     fields: [
-      { id: 'campo1', label: 'Campo 1', type: 'text', capitalization: 'LOWERCASE' },
-      { id: 'campo2', label: 'Campo 2', type: 'text', capitalization: 'LOWERCASE' }
+      { id: 'campo1', label: `${t('configurator.newFieldLabel')} 1`, type: 'text', capitalization: 'LOWERCASE' },
+      { id: 'campo2', label: `${t('configurator.newFieldLabel')} 2`, type: 'text', capitalization: 'LOWERCASE' }
     ]
   }
   editingFormat.value = newFormat
@@ -143,7 +162,7 @@ const updatePreview = (format: BranchFormatTemplate) => {
 const handleExport = () => {
   const dataStr = FormatManager.exportCustomFormats()
   if (dataStr === '[]') {
-    alert('No hay formatos personalizados para exportar.')
+    alert(t('configurator.exportEmpty'))
     return
   }
   const dataUri = 'data:application/json;charset=utf-8,'+ encodeURIComponent(dataStr)
@@ -165,9 +184,9 @@ const handleImport = (event: Event) => {
       const jsonStr = e.target?.result as string
       FormatManager.importCustomFormats(jsonStr)
       loadFormats()
-      alert('Formatos importados correctamente.')
+      alert(t('configurator.importSuccess'))
     } catch (err) {
-      alert('Error al importar formatos. Archivo inválido.')
+      alert(t('configurator.importError'))
     }
   }
   reader.readAsText(file)
@@ -187,13 +206,14 @@ const handleImport = (event: Event) => {
         @save="handleSave"
         @cancel="handleCancel"
         @toggle-visibility="handleToggleVisibilityInEditor"
+        @update-language="handleUpdateLanguageInEditor"
       />
     </div>
 
     <div v-else class="formats-list-section">
       <div class="list-header">
-        <h3>Formatos Disponibles</h3>
-        <button class="btn-primary" @click="startNewFormat">Crear Formato</button>
+        <h3>{{ $t('configurator.availableFormats') }}</h3>
+        <button class="btn-primary" @click="startNewFormat">{{ $t('configurator.createFormat') }}</button>
       </div>
 
       <div class="format-items">
@@ -209,25 +229,25 @@ const handleImport = (event: Event) => {
         >
           <div class="format-info">
             <span class="format-name">
-              {{ format.name }}
-              <span v-if="format.isReadonly" class="badge">Predeterminado</span>
-              <span v-if="format.id === defaultFormatId" class="badge badge--selected">Seleccionado</span>
-              <span v-if="!format.isVisible" class="badge">Oculto</span>
+              {{ format.name.includes('.') ? $t(format.name) : format.name }}
+              <span v-if="format.isReadonly" class="badge">{{ $t('configurator.badgeBuiltin') }}</span>
+              <span v-if="format.id === defaultFormatId" class="badge badge--selected">{{ $t('configurator.badgeSelected') }}</span>
+              <span v-if="!format.isVisible" class="badge">{{ $t('configurator.badgeHidden') }}</span>
             </span>
             <code class="format-template">{{ format.templateString }}</code>
           </div>
           <div class="format-actions" @click.stop>
-            <button class="btn-secondary small-btn" @click="handleEdit(format)">Editar</button>
-            <button v-if="format.isReadonly" class="btn-secondary small-btn" @click="handleClone(format.id)">Clonar</button>
-            <button v-else class="btn-secondary small-btn delete-btn" @click="promptDelete(format.id)">Borrar</button>
+            <button class="btn-secondary small-btn" @click="handleEdit(format)">{{ $t('configurator.edit') }}</button>
+            <button v-if="format.isReadonly" class="btn-secondary small-btn" @click="handleClone(format.id)">{{ $t('configurator.clone') }}</button>
+            <button v-else class="btn-secondary small-btn delete-btn" @click="promptDelete(format.id)">{{ $t('configurator.delete') }}</button>
           </div>
         </div>
       </div>
 
       <div class="import-export-section">
-        <button class="btn-secondary" @click="handleExport">Exportar Personalizados</button>
+        <button class="btn-secondary" @click="handleExport">{{ $t('configurator.exportCustom') }}</button>
         <label class="btn-secondary file-upload-btn">
-          Importar JSON
+          {{ $t('configurator.importJson') }}
           <input type="file" accept=".json" @change="handleImport" hidden />
         </label>
       </div>
@@ -235,17 +255,17 @@ const handleImport = (event: Event) => {
       <div class="back-section">
         <button class="btn-secondary back-btn" @click="emit('close')">
           <ArrowLeftIcon class="icon" />
-          <span>Volver</span>
+          <span>{{ $t('configurator.back') }}</span>
         </button>
       </div>
     </div>
 
     <CustomModal
       v-model="showDeleteModal"
-      title="Eliminar Formato"
-      message="¿Estás seguro de que quieres eliminar este formato personalizado? Esta acción no se puede deshacer."
-      confirmText="Borrar"
-      cancelText="Cancelar"
+      :title="$t('configurator.deleteModal.title')"
+      :message="$t('configurator.deleteModal.message')"
+      :confirmText="$t('configurator.delete')"
+      :cancelText="$t('common.cancel')"
       :danger="true"
       @confirm="confirmDelete"
       @cancel="cancelDelete"

--- a/src/components/AppConfigurationView.vue
+++ b/src/components/AppConfigurationView.vue
@@ -1,0 +1,298 @@
+<script setup lang="ts">
+import { ref, onMounted } from 'vue'
+import { FormatManager } from '@/core/FormatManager'
+import type { BranchFormatTemplate } from '@/core/FormatTypes'
+import FormatPreview from '@/components/FormatPreview.vue'
+import FormatEditor from '@/components/FormatEditor.vue'
+
+const formats = ref<BranchFormatTemplate[]>([])
+const editingFormat = ref<BranchFormatTemplate | null>(null)
+const previewFormat = ref<BranchFormatTemplate | null>(null)
+
+const loadFormats = () => {
+  formats.value = FormatManager.getFormats()
+}
+
+onMounted(() => {
+  loadFormats()
+  if (formats.value.length > 0) {
+    previewFormat.value = formats.value[0]
+  }
+})
+
+const handleEdit = (format: BranchFormatTemplate) => {
+  editingFormat.value = format
+  previewFormat.value = format
+}
+
+const handleClone = (formatId: string) => {
+  const cloned = FormatManager.cloneFormat(formatId)
+  if (cloned) {
+    loadFormats()
+    handleEdit(cloned)
+  }
+}
+
+const handleToggleVisibility = (formatId: string) => {
+  FormatManager.toggleVisibility(formatId)
+  loadFormats()
+}
+
+const handleDelete = (formatId: string) => {
+  if (confirm('¿Seguro que quieres eliminar este formato?')) {
+    FormatManager.deleteFormat(formatId)
+    loadFormats()
+    if (previewFormat.value?.id === formatId) {
+      previewFormat.value = formats.value[0] || null
+    }
+  }
+}
+
+const startNewFormat = () => {
+  const newFormat: BranchFormatTemplate = {
+    id: `custom-${Date.now()}`,
+    name: 'Nuevo Formato',
+    templateString: '{campo1}-{campo2}',
+    isReadonly: false,
+    isVisible: true,
+    fields: [
+      { id: 'campo1', label: 'Campo 1', operations: ['LOWERCASE'] },
+      { id: 'campo2', label: 'Campo 2', operations: ['LOWERCASE'] }
+    ]
+  }
+  editingFormat.value = newFormat
+  previewFormat.value = newFormat
+}
+
+const handleSave = (savedFormat: BranchFormatTemplate) => {
+  const exists = formats.value.some(f => f.id === savedFormat.id)
+  if (exists) {
+    FormatManager.updateFormat(savedFormat)
+  } else {
+    FormatManager.addFormat(savedFormat)
+  }
+  editingFormat.value = null
+  loadFormats()
+  previewFormat.value = savedFormat
+}
+
+const handleCancel = () => {
+  editingFormat.value = null
+  previewFormat.value = formats.value[0] || null
+}
+
+const updatePreview = (format: BranchFormatTemplate) => {
+  previewFormat.value = format
+}
+
+// Import/Export
+const handleExport = () => {
+  const dataStr = FormatManager.exportCustomFormats()
+  if (dataStr === '[]') {
+    alert('No hay formatos personalizados para exportar.')
+    return
+  }
+  const dataUri = 'data:application/json;charset=utf-8,'+ encodeURIComponent(dataStr)
+  const exportFileDefaultName = 'branch-formats.json'
+  const linkElement = document.createElement('a')
+  linkElement.setAttribute('href', dataUri)
+  linkElement.setAttribute('download', exportFileDefaultName)
+  linkElement.click()
+}
+
+const handleImport = (event: Event) => {
+  const target = event.target as HTMLInputElement
+  const file = target.files?.[0]
+  if (!file) return
+
+  const reader = new FileReader()
+  reader.onload = (e) => {
+    try {
+      const jsonStr = e.target?.result as string
+      FormatManager.importCustomFormats(jsonStr)
+      loadFormats()
+      alert('Formatos importados correctamente.')
+    } catch (err) {
+      alert('Error al importar formatos. Archivo inválido.')
+    }
+  }
+  reader.readAsText(file)
+  target.value = '' // reset input
+}
+
+</script>
+
+<template>
+  <div class="configuration-view">
+    <FormatPreview :format="previewFormat" />
+
+    <div v-if="editingFormat">
+      <FormatEditor 
+        :format="editingFormat" 
+        @update:format="updatePreview"
+        @save="handleSave"
+        @cancel="handleCancel"
+      />
+    </div>
+
+    <div v-else class="formats-list-section">
+      <div class="list-header">
+        <h3>Formatos Disponibles</h3>
+        <button class="btn-primary" @click="startNewFormat">Crear Formato</button>
+      </div>
+
+      <div class="format-items">
+        <div v-for="format in formats" :key="format.id" class="format-card" @click="previewFormat = format">
+          <div class="format-info">
+            <span class="format-name">{{ format.name }} <span v-if="format.isReadonly" class="badge">Predeterminado</span></span>
+            <code class="format-template">{{ format.templateString }}</code>
+          </div>
+          <div class="format-actions" @click.stop>
+            <label class="toggle-visibility">
+              <input type="checkbox" :checked="format.isVisible" @change="handleToggleVisibility(format.id)" />
+              Visible en App
+            </label>
+            <button v-if="format.isReadonly" class="btn-secondary small-btn" @click="handleClone(format.id)">Clonar</button>
+            <template v-else>
+              <button class="btn-secondary small-btn" @click="handleEdit(format)">Editar</button>
+              <button class="btn-secondary small-btn delete-btn" @click="handleDelete(format.id)">Borrar</button>
+            </template>
+          </div>
+        </div>
+      </div>
+
+      <div class="import-export-section">
+        <button class="btn-secondary" @click="handleExport">Exportar Personalizados</button>
+        <label class="btn-secondary file-upload-btn">
+          Importar JSON
+          <input type="file" accept=".json" @change="handleImport" hidden />
+        </label>
+      </div>
+    </div>
+  </div>
+</template>
+
+<style scoped lang="scss">
+.configuration-view {
+  background-color: var(--bg-surface);
+  padding: 2rem;
+  border-radius: 12px;
+  border: 1px solid var(--border-color);
+  margin-bottom: 2rem;
+  box-shadow: 0 4px 6px -1px rgba(0, 0, 0, 0.05);
+}
+
+.list-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 1.5rem;
+  
+  h3 {
+    margin: 0;
+    color: var(--text-main);
+  }
+}
+
+.format-items {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.format-card {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 1rem;
+  border: 1px solid var(--border-color);
+  border-radius: 8px;
+  background-color: var(--bg-surface);
+  cursor: pointer;
+  transition: border-color 0.2s;
+
+  &:hover {
+    border-color: var(--text-main);
+  }
+
+  @media (max-width: 600px) {
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 1rem;
+  }
+}
+
+.format-info {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+}
+
+.format-name {
+  font-weight: 600;
+  color: var(--text-main);
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.badge {
+  font-size: 0.7rem;
+  padding: 0.1rem 0.4rem;
+  border-radius: 9999px;
+  background-color: var(--border-color);
+  color: var(--text-muted);
+}
+
+.format-template {
+  font-size: 0.85rem;
+  color: var(--text-muted);
+}
+
+.format-actions {
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+  
+  @media (max-width: 600px) {
+    width: 100%;
+    justify-content: space-between;
+  }
+}
+
+.toggle-visibility {
+  font-size: 0.85rem;
+  color: var(--text-main);
+  display: flex;
+  align-items: center;
+  gap: 0.25rem;
+  cursor: pointer;
+}
+
+.small-btn {
+  padding: 0.25rem 0.75rem;
+  font-size: 0.85rem;
+}
+
+.delete-btn {
+  color: #ef4444;
+  border-color: #fca5a5;
+  &:hover {
+    background-color: #fee2e2;
+  }
+}
+
+.import-export-section {
+  display: flex;
+  justify-content: center;
+  gap: 1rem;
+  margin-top: 2rem;
+  padding-top: 1.5rem;
+  border-top: 1px solid var(--border-color);
+}
+
+.file-upload-btn {
+  cursor: pointer;
+  margin: 0;
+}
+</style>

--- a/src/components/AppConfigurationView.vue
+++ b/src/components/AppConfigurationView.vue
@@ -4,10 +4,18 @@ import { FormatManager } from '@/core/FormatManager'
 import type { BranchFormatTemplate } from '@/core/FormatTypes'
 import FormatPreview from '@/components/FormatPreview.vue'
 import FormatEditor from '@/components/FormatEditor.vue'
+import CustomModal from '@/components/CustomModal.vue'
+import ArrowLeftIcon from '@/components/ArrowLeftIcon.vue'
+
+const emit = defineEmits(['close'])
 
 const formats = ref<BranchFormatTemplate[]>([])
 const editingFormat = ref<BranchFormatTemplate | null>(null)
 const previewFormat = ref<BranchFormatTemplate | null>(null)
+const defaultFormatId = ref<string | null>(null)
+
+const showDeleteModal = ref(false)
+const formatToDelete = ref<string | null>(null)
 
 const loadFormats = () => {
   formats.value = FormatManager.getFormats()
@@ -16,9 +24,27 @@ const loadFormats = () => {
 onMounted(() => {
   loadFormats()
   if (formats.value.length > 0) {
-    previewFormat.value = formats.value[0]
+    const storedDefaultId = FormatManager.getDefaultFormatId()
+    const storedDefault = formats.value.find(f => f.id === storedDefaultId)
+    previewFormat.value = storedDefault || formats.value[0]
+    defaultFormatId.value = previewFormat.value.id
   }
 })
+
+// Devuelve el formato que debe verse en la previsualización cuando no hay uno
+// explícito que mostrar (tras cerrar el editor, borrar, etc.): el predeterminado
+// actual si sigue existiendo, o si no el primero de la lista.
+const getPreviewFallback = (): BranchFormatTemplate | null => {
+  return formats.value.find(f => f.id === defaultFormatId.value) || formats.value[0] || null
+}
+
+// Al hacer clic en una tarjeta se previsualiza y, a la vez, se marca como
+// el formato predeterminado de la app.
+const selectFormat = (format: BranchFormatTemplate) => {
+  previewFormat.value = format
+  defaultFormatId.value = format.id
+  FormatManager.setDefaultFormatId(format.id)
+}
 
 const handleEdit = (format: BranchFormatTemplate) => {
   editingFormat.value = format
@@ -33,19 +59,46 @@ const handleClone = (formatId: string) => {
   }
 }
 
-const handleToggleVisibility = (formatId: string) => {
-  FormatManager.toggleVisibility(formatId)
+const handleToggleVisibilityInEditor = () => {
+  if (!editingFormat.value) return
+  const { id, isVisible } = editingFormat.value
+  FormatManager.setVisibility(id, !isVisible)
+
+  // Un formato oculto no puede seguir siendo el predeterminado de la app.
+  if (defaultFormatId.value === id && isVisible) {
+    loadFormats()
+    defaultFormatId.value = formats.value.find(f => f.isVisible)?.id ?? null
+    FormatManager.setDefaultFormatId(defaultFormatId.value ?? '')
+  }
+
   loadFormats()
+  const refreshed = formats.value.find(f => f.id === id) || null
+  editingFormat.value = refreshed
+  previewFormat.value = refreshed
 }
 
-const handleDelete = (formatId: string) => {
-  if (confirm('¿Seguro que quieres eliminar este formato?')) {
-    FormatManager.deleteFormat(formatId)
+const promptDelete = (formatId: string) => {
+  formatToDelete.value = formatId
+  showDeleteModal.value = true
+}
+
+const confirmDelete = () => {
+  if (formatToDelete.value) {
+    FormatManager.deleteFormat(formatToDelete.value)
     loadFormats()
-    if (previewFormat.value?.id === formatId) {
-      previewFormat.value = formats.value[0] || null
+    if (defaultFormatId.value === formatToDelete.value) {
+      defaultFormatId.value = formats.value[0]?.id ?? null
+      FormatManager.setDefaultFormatId(defaultFormatId.value ?? '')
+    }
+    if (previewFormat.value?.id === formatToDelete.value) {
+      previewFormat.value = getPreviewFallback()
     }
   }
+  formatToDelete.value = null
+}
+
+const cancelDelete = () => {
+  formatToDelete.value = null
 }
 
 const startNewFormat = () => {
@@ -55,9 +108,10 @@ const startNewFormat = () => {
     templateString: '{campo1}-{campo2}',
     isReadonly: false,
     isVisible: true,
+    language: 'es',
     fields: [
-      { id: 'campo1', label: 'Campo 1', operations: ['LOWERCASE'] },
-      { id: 'campo2', label: 'Campo 2', operations: ['LOWERCASE'] }
+      { id: 'campo1', label: 'Campo 1', type: 'text', capitalization: 'LOWERCASE' },
+      { id: 'campo2', label: 'Campo 2', type: 'text', capitalization: 'LOWERCASE' }
     ]
   }
   editingFormat.value = newFormat
@@ -78,7 +132,7 @@ const handleSave = (savedFormat: BranchFormatTemplate) => {
 
 const handleCancel = () => {
   editingFormat.value = null
-  previewFormat.value = formats.value[0] || null
+  previewFormat.value = getPreviewFallback()
 }
 
 const updatePreview = (format: BranchFormatTemplate) => {
@@ -123,15 +177,16 @@ const handleImport = (event: Event) => {
 </script>
 
 <template>
-  <div class="configuration-view">
+  <div class="configuration-view container-wide">
     <FormatPreview :format="previewFormat" />
 
     <div v-if="editingFormat">
-      <FormatEditor 
-        :format="editingFormat" 
+      <FormatEditor
+        :format="editingFormat"
         @update:format="updatePreview"
         @save="handleSave"
         @cancel="handleCancel"
+        @toggle-visibility="handleToggleVisibilityInEditor"
       />
     </div>
 
@@ -142,21 +197,29 @@ const handleImport = (event: Event) => {
       </div>
 
       <div class="format-items">
-        <div v-for="format in formats" :key="format.id" class="format-card" @click="previewFormat = format">
+        <div
+          v-for="format in formats"
+          :key="format.id"
+          class="format-card"
+          :class="{
+            'format-card--selected': format.id === defaultFormatId,
+            'format-card--hidden': !format.isVisible
+          }"
+          @click="selectFormat(format)"
+        >
           <div class="format-info">
-            <span class="format-name">{{ format.name }} <span v-if="format.isReadonly" class="badge">Predeterminado</span></span>
+            <span class="format-name">
+              {{ format.name }}
+              <span v-if="format.isReadonly" class="badge">Predeterminado</span>
+              <span v-if="format.id === defaultFormatId" class="badge badge--selected">Seleccionado</span>
+              <span v-if="!format.isVisible" class="badge">Oculto</span>
+            </span>
             <code class="format-template">{{ format.templateString }}</code>
           </div>
           <div class="format-actions" @click.stop>
-            <label class="toggle-visibility">
-              <input type="checkbox" :checked="format.isVisible" @change="handleToggleVisibility(format.id)" />
-              Visible en App
-            </label>
+            <button class="btn-secondary small-btn" @click="handleEdit(format)">Editar</button>
             <button v-if="format.isReadonly" class="btn-secondary small-btn" @click="handleClone(format.id)">Clonar</button>
-            <template v-else>
-              <button class="btn-secondary small-btn" @click="handleEdit(format)">Editar</button>
-              <button class="btn-secondary small-btn delete-btn" @click="handleDelete(format.id)">Borrar</button>
-            </template>
+            <button v-else class="btn-secondary small-btn delete-btn" @click="promptDelete(format.id)">Borrar</button>
           </div>
         </div>
       </div>
@@ -168,7 +231,25 @@ const handleImport = (event: Event) => {
           <input type="file" accept=".json" @change="handleImport" hidden />
         </label>
       </div>
+
+      <div class="back-section">
+        <button class="btn-secondary back-btn" @click="emit('close')">
+          <ArrowLeftIcon class="icon" />
+          <span>Volver</span>
+        </button>
+      </div>
     </div>
+
+    <CustomModal
+      v-model="showDeleteModal"
+      title="Eliminar Formato"
+      message="¿Estás seguro de que quieres eliminar este formato personalizado? Esta acción no se puede deshacer."
+      confirmText="Borrar"
+      cancelText="Cancelar"
+      :danger="true"
+      @confirm="confirmDelete"
+      @cancel="cancelDelete"
+    />
   </div>
 </template>
 
@@ -180,17 +261,31 @@ const handleImport = (event: Event) => {
   border: 1px solid var(--border-color);
   margin-bottom: 2rem;
   box-shadow: 0 4px 6px -1px rgba(0, 0, 0, 0.05);
+
+  @media (max-width: vars.$bp-mobile) {
+    padding: 1.5rem;
+  }
 }
 
 .list-header {
   display: flex;
   justify-content: space-between;
   align-items: center;
+  gap: 1rem;
   margin-bottom: 1.5rem;
-  
+
   h3 {
     margin: 0;
     color: var(--text-main);
+  }
+
+  @media (max-width: vars.$bp-mobile) {
+    flex-direction: column;
+    align-items: flex-start;
+
+    .btn-primary {
+      width: 100%;
+    }
   }
 }
 
@@ -202,8 +297,9 @@ const handleImport = (event: Event) => {
 
 .format-card {
   display: flex;
-  justify-content: space-between;
-  align-items: center;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 1rem;
   padding: 1rem;
   border: 1px solid var(--border-color);
   border-radius: 8px;
@@ -215,10 +311,19 @@ const handleImport = (event: Event) => {
     border-color: var(--text-main);
   }
 
-  @media (max-width: 600px) {
-    flex-direction: column;
-    align-items: flex-start;
-    gap: 1rem;
+  &--selected {
+    border-color: var(--accent-color);
+    box-shadow: 0 0 0 1px var(--accent-color);
+  }
+
+  &--hidden .format-info {
+    opacity: 0.55;
+  }
+
+  @media (min-width: vars.$bp-mobile) {
+    flex-direction: row;
+    justify-content: space-between;
+    align-items: center;
   }
 }
 
@@ -242,6 +347,11 @@ const handleImport = (event: Event) => {
   border-radius: 9999px;
   background-color: var(--border-color);
   color: var(--text-muted);
+
+  &--selected {
+    background-color: var(--accent-color);
+    color: var(--bg-body);
+  }
 }
 
 .format-template {
@@ -253,20 +363,13 @@ const handleImport = (event: Event) => {
   display: flex;
   align-items: center;
   gap: 1rem;
-  
-  @media (max-width: 600px) {
-    width: 100%;
-    justify-content: space-between;
-  }
-}
+  width: 100%;
+  justify-content: space-between;
 
-.toggle-visibility {
-  font-size: 0.85rem;
-  color: var(--text-main);
-  display: flex;
-  align-items: center;
-  gap: 0.25rem;
-  cursor: pointer;
+  @media (min-width: vars.$bp-mobile) {
+    width: auto;
+    justify-content: flex-end;
+  }
 }
 
 .small-btn {
@@ -294,5 +397,17 @@ const handleImport = (event: Event) => {
 .file-upload-btn {
   cursor: pointer;
   margin: 0;
+}
+
+.back-section {
+  display: flex;
+  justify-content: center;
+  margin-top: 1.5rem;
+}
+
+.back-btn {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
 }
 </style>

--- a/src/components/AppHeader.vue
+++ b/src/components/AppHeader.vue
@@ -1,0 +1,124 @@
+<script setup lang="ts">
+import LangSelector from '@/components/LangSelector.vue'
+import SettingsIcon from '@/components/SettingsIcon.vue'
+
+const props = defineProps<{
+  showConfig: boolean;
+  languages: { code: string; label: string }[];
+}>();
+
+const emit = defineEmits<{
+  (e: 'toggleConfig'): void;
+  (e: 'home'): void;
+}>();
+</script>
+
+<template>
+  <header class="navbar">
+    <div class="navbar-container">
+      <button class="navbar-brand" @click="emit('home')" :aria-label="$t('hero.title')">
+        <h1 class="title">{{ $t('hero.title') }}</h1>
+      </button>
+
+      <div class="navbar-actions">
+        <LangSelector
+          :modelValue="$i18n.locale"
+          @update:modelValue="$i18n.locale = $event"
+          :options="languages"
+        />
+
+        <button
+          class="btn-secondary config-toggle"
+          :class="{ 'config-toggle--active': showConfig }"
+          :aria-pressed="showConfig"
+          @click="emit('toggleConfig')"
+        >
+          <SettingsIcon class="icon" />
+          <span class="text">Configuración</span>
+        </button>
+      </div>
+    </div>
+  </header>
+</template>
+
+<style scoped lang="scss">
+.navbar {
+  background-color: var(--bg-surface);
+  border-bottom: 1px solid var(--border-color);
+  position: sticky;
+  top: 0;
+  z-index: 100;
+  padding: 0.75rem 0;
+  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.05);
+}
+
+.navbar-container {
+  padding: 0 1.5rem;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
+
+.navbar-brand {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  background: none;
+  border: none;
+  padding: 0;
+  cursor: pointer;
+  font-family: inherit;
+  border-radius: 6px;
+
+  &:focus-visible {
+    outline: 2px solid var(--accent-color);
+    outline-offset: 4px;
+  }
+}
+
+.title {
+  font-size: 1.25rem;
+  font-weight: 700;
+  letter-spacing: -0.02em;
+  color: var(--text-main);
+  margin: 0;
+}
+
+.navbar-actions {
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+}
+
+.config-toggle {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  font-size: 0.9rem;
+  padding: 0.4rem 0.8rem;
+
+  &--active {
+    background-color: var(--accent-color);
+    color: var(--bg-body);
+    border-color: var(--accent-color);
+
+    &:hover {
+      background-color: var(--accent-color);
+      border-color: var(--accent-color);
+      opacity: 0.9;
+    }
+  }
+}
+
+@media (max-width: vars.$bp-mobile) {
+  .navbar-container {
+    padding: 0 1rem;
+  }
+  .title {
+    font-size: 1.05rem;
+  }
+  .config-toggle .text {
+    display: none; // hide text on mobile, just show icon
+  }
+}
+</style>

--- a/src/components/AppHeader.vue
+++ b/src/components/AppHeader.vue
@@ -34,7 +34,7 @@ const emit = defineEmits<{
           @click="emit('toggleConfig')"
         >
           <SettingsIcon class="icon" />
-          <span class="text">Configuración</span>
+          <span class="text">{{ $t('header.config') }}</span>
         </button>
       </div>
     </div>

--- a/src/components/AppMainView.vue
+++ b/src/components/AppMainView.vue
@@ -53,7 +53,7 @@ const handleDeleteBranch = (branchId: number) => {
 </script>
 
 <template>
-  <main class="main-content">
+  <main class="main-content container">
     <div class="converter-box">
       <BranchForm @submitForm="handleFormSubmit" />
     </div>
@@ -92,7 +92,7 @@ const handleDeleteBranch = (branchId: number) => {
   box-shadow: 0 4px 6px -1px rgba(0, 0, 0, 0.05);
 }
 
-@media (max-width: 600px) {
+@media (max-width: vars.$bp-mobile) {
   .converter-box {
     padding: 1.5rem;
   }

--- a/src/components/AppMainView.vue
+++ b/src/components/AppMainView.vue
@@ -29,15 +29,9 @@ const updateBranches = () => {
 
 // Now handleFormSubmit receives both the template and the form data
 const handleFormSubmit = (template: BranchFormatTemplate, formData: BranchFormType) => {
-  // We need to update branchManager to accept template or just format it here.
-  // Actually BranchManager should receive the branchName directly or the template + values.
-  // For now, let's keep BranchManager API as simple as possible.
-  // Wait, Branch constructor expects `BranchType` which now has `branchName`.
-  
   import('@/core/BranchFormatter').then(({ BranchFormatter }) => {
     const branchName = BranchFormatter.format(template, formData)
     branchManager.createBranch({ 
-      id: Date.now(), 
       branchName, 
       formatId: template.id 
     })

--- a/src/components/AppMainView.vue
+++ b/src/components/AppMainView.vue
@@ -1,0 +1,152 @@
+<script setup lang="ts">
+import { ref } from 'vue'
+import BranchForm from '@/components/BranchForm.vue'
+import BranchList from '@/components/BranchList.vue'
+import { BranchManager } from '@/core/BranchManager'
+import type { BranchFormType } from '@/core/BranchTypes'
+import type { Branch } from '@/core/Branch'
+import type { BranchFormatTemplate } from '@/core/FormatTypes'
+import { FormatManager } from '@/core/FormatManager'
+
+const branchManager = BranchManager.getInstance()
+
+const branches = ref<Branch[]>(branchManager.getBranches())
+const showHistory = ref(false)
+const latestBranch = ref<Branch | null>(null)
+const copied = ref(false)
+
+const copyToClipboard = async (text: string) => {
+  await navigator.clipboard.writeText(text)
+  copied.value = true
+  setTimeout(() => {
+    copied.value = false
+  }, 2000)
+}
+
+const updateBranches = () => {
+  branches.value = [...branchManager.getBranches()]
+}
+
+// Now handleFormSubmit receives both the template and the form data
+const handleFormSubmit = (template: BranchFormatTemplate, formData: BranchFormType) => {
+  // We need to update branchManager to accept template or just format it here.
+  // Actually BranchManager should receive the branchName directly or the template + values.
+  // For now, let's keep BranchManager API as simple as possible.
+  // Wait, Branch constructor expects `BranchType` which now has `branchName`.
+  
+  import('@/core/BranchFormatter').then(({ BranchFormatter }) => {
+    const branchName = BranchFormatter.format(template, formData)
+    branchManager.createBranch({ 
+      id: Date.now(), 
+      branchName, 
+      formatId: template.id 
+    })
+    updateBranches()
+    latestBranch.value = branches.value[0] || null
+  })
+}
+
+const handleDeleteBranch = (branchId: number) => {
+  branchManager.deleteBranch(branchId)
+  updateBranches()
+}
+</script>
+
+<template>
+  <main class="main-content">
+    <div class="converter-box">
+      <BranchForm @submitForm="handleFormSubmit" />
+    </div>
+
+    <div v-if="latestBranch" class="result-section">
+      <h2 class="result-title">{{ $t('result.title') }}</h2>
+      <div class="result-card">
+        <code class="result-code">{{ latestBranch.branchName }}</code>
+        <button class="btn-primary" @click="copyToClipboard(latestBranch.branchName)">
+          {{ copied ? $t('result.copied') : $t('result.copy') }}
+        </button>
+      </div>
+    </div>
+
+    <div class="history-section">
+      <div class="history-header">
+        <button class="btn-secondary toggle-btn" @click="showHistory = !showHistory">
+          {{ showHistory ? $t('history.hide') : $t('history.show') }}
+        </button>
+      </div>
+
+      <div v-if="showHistory" class="history-pane">
+        <BranchList :branches="branches" @deleteBranch="handleDeleteBranch" />
+      </div>
+    </div>
+  </main>
+</template>
+
+<style scoped lang="scss">
+.converter-box {
+  background-color: var(--bg-surface);
+  padding: 2rem;
+  border-radius: 12px;
+  border: 1px solid var(--border-color);
+  margin-bottom: 2rem;
+  box-shadow: 0 4px 6px -1px rgba(0, 0, 0, 0.05);
+}
+
+@media (max-width: 600px) {
+  .converter-box {
+    padding: 1.5rem;
+  }
+  .result-code {
+    font-size: 1.25rem;
+  }
+}
+
+.result-section {
+  animation: fadeIn 0.3s ease-out;
+  margin-bottom: 3rem;
+}
+
+.result-title {
+  font-size: 0.9rem;
+  font-weight: 600;
+  color: var(--text-muted);
+  margin-bottom: 0.75rem;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  text-align: center;
+}
+
+.result-card {
+  background-color: var(--bg-surface);
+  border: 1px solid var(--border-color);
+  border-radius: 12px;
+  padding: 1.5rem;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 1.5rem;
+}
+
+.result-code {
+  font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
+  font-size: 1.5rem;
+  font-weight: 600;
+  color: var(--text-main);
+  word-break: break-all;
+  text-align: center;
+}
+
+.history-section {
+  margin-top: 4rem;
+}
+
+.history-header {
+  display: flex;
+  justify-content: center;
+  margin-bottom: 2rem;
+}
+
+.history-pane {
+  animation: fadeIn 0.3s ease-out;
+}
+</style>

--- a/src/components/ArrowLeftIcon.vue
+++ b/src/components/ArrowLeftIcon.vue
@@ -1,0 +1,29 @@
+<!-- src/components/ArrowLeftIcon.vue -->
+<script setup lang="ts"></script>
+
+<template>
+  <svg
+    class="arrow-left-icon"
+    viewBox="0 0 24 24"
+    xmlns="http://www.w3.org/2000/svg"
+    fill="none"
+    stroke="currentColor"
+    stroke-width="2"
+    stroke-linecap="round"
+    stroke-linejoin="round"
+    aria-hidden="true"
+    focusable="false"
+  >
+    <path d="M19 12H5" />
+    <path d="M12 19l-7-7 7-7" />
+  </svg>
+</template>
+
+<style scoped lang="scss">
+.arrow-left-icon {
+  width: 1.1rem;
+  height: 1.1rem;
+  flex-shrink: 0;
+  display: inline-block;
+}
+</style>

--- a/src/components/BranchForm.vue
+++ b/src/components/BranchForm.vue
@@ -1,72 +1,79 @@
 <script setup lang="ts">
-import { ref, watch } from 'vue'
-import type { BranchFormType } from '@/core/BranchTypes.ts'
-
-const projectId = ref('')
-const ticketId = ref('')
-const featureName = ref('')
+import { ref, watch, onMounted, computed } from 'vue'
+import type { BranchFormType } from '@/core/BranchTypes'
+import type { BranchFormatTemplate } from '@/core/FormatTypes'
+import { FormatManager } from '@/core/FormatManager'
 
 const emit = defineEmits(['submitForm'])
+
+const availableFormats = ref<BranchFormatTemplate[]>([])
+const selectedFormatId = ref<string>('')
+const formData = ref<Record<string, string>>({})
+
+onMounted(() => {
+  availableFormats.value = FormatManager.getVisibleFormats()
+  if (availableFormats.value.length > 0) {
+    selectedFormatId.value = availableFormats.value[0].id
+  }
+})
+
+const selectedFormat = computed(() => {
+  return availableFormats.value.find(f => f.id === selectedFormatId.value) || null
+})
+
+watch(selectedFormatId, () => {
+  formData.value = {}
+})
 
 const handleSubmit = (event: Event) => {
   event.preventDefault()
 
   if (!validateInput()) return
 
-  emit('submitForm', {
-    projectId: projectId.value,
-    ticketId: ticketId.value,
-    featureName: featureName.value
-  } as BranchFormType)
-
-  cleanInput()
+  if (selectedFormat.value) {
+    emit('submitForm', selectedFormat.value, { ...formData.value } as BranchFormType)
+    cleanInput()
+  }
 }
 
 function validateInput() {
-  return projectId.value && ticketId.value && featureName.value
+  if (!selectedFormat.value) return false
+  for (const field of selectedFormat.value.fields) {
+    if (!formData.value[field.id]) return false
+  }
+  return true
 }
 
 function cleanInput() {
-  projectId.value = ''
-  ticketId.value = ''
-  featureName.value = ''
+  formData.value = {}
 }
 </script>
 
 <template>
   <form class="form" aria-label="Create branch name form" @submit="handleSubmit">
-    <div class="form-group">
-      <label class="form-label">{{ $t('form.projectId') }}</label>
-      <input
-        class="input-element"
-        type="text"
-        name="project-id"
-        v-model="projectId"
-        :placeholder="$t('form.projectIdPlaceholder')"
-      />
+    
+    <div class="form-group" v-if="availableFormats.length > 1">
+      <label class="form-label">Formato</label>
+      <select class="input-element select-element" v-model="selectedFormatId">
+        <option v-for="format in availableFormats" :key="format.id" :value="format.id">
+          {{ format.name }}
+        </option>
+      </select>
     </div>
 
-    <div class="form-group">
-      <label class="form-label">{{ $t('form.ticketId') }}</label>
-      <input
-        class="input-element"
-        type="text"
-        name="ticket-id"
-        v-model="ticketId"
-        :placeholder="$t('form.ticketIdPlaceholder')"
-      />
-    </div>
-
-    <div class="form-group">
-      <label class="form-label">{{ $t('form.developName') }}</label>
-      <input
-        class="input-element"
-        type="text"
-        name="develop-name"
-        v-model="featureName"
-        :placeholder="$t('form.developNamePlaceholder')"
-      />
-    </div>
+    <template v-if="selectedFormat">
+      <div class="form-group" v-for="field in selectedFormat.fields" :key="field.id">
+        <label class="form-label">
+           {{ field.label.includes('.') ? $t(field.label) : field.label }}
+        </label>
+        <input
+          class="input-element"
+          type="text"
+          :name="field.id"
+          v-model="formData[field.id]"
+        />
+      </div>
+    </template>
 
     <button class="btn-primary generate-btn" type="submit">
       {{ $t('form.generate') }}
@@ -98,6 +105,16 @@ function cleanInput() {
 
 .input-element {
   width: 100%;
+}
+
+.select-element {
+  background-color: var(--bg-surface);
+  color: var(--text-main);
+  border: 1px solid var(--border-color);
+  border-radius: 6px;
+  padding: 0.75rem 1rem;
+  font-size: 1rem;
+  appearance: auto;
 }
 
 .generate-btn {

--- a/src/components/BranchForm.vue
+++ b/src/components/BranchForm.vue
@@ -3,6 +3,7 @@ import { ref, watch, onMounted, computed } from 'vue'
 import type { BranchFormType } from '@/core/BranchTypes'
 import type { BranchFormatTemplate } from '@/core/FormatTypes'
 import { FormatManager } from '@/core/FormatManager'
+import CustomSelect from '@/components/CustomSelect.vue'
 
 const emit = defineEmits(['submitForm'])
 
@@ -13,7 +14,9 @@ const formData = ref<Record<string, string>>({})
 onMounted(() => {
   availableFormats.value = FormatManager.getVisibleFormats()
   if (availableFormats.value.length > 0) {
-    selectedFormatId.value = availableFormats.value[0].id
+    const defaultId = FormatManager.getDefaultFormatId()
+    const defaultStillAvailable = availableFormats.value.some(f => f.id === defaultId)
+    selectedFormatId.value = defaultStillAvailable ? defaultId! : availableFormats.value[0].id
   }
 })
 
@@ -21,8 +24,20 @@ const selectedFormat = computed(() => {
   return availableFormats.value.find(f => f.id === selectedFormatId.value) || null
 })
 
+const formatOptions = computed(() => {
+  return availableFormats.value.map(f => ({ value: f.id, label: f.name }))
+})
+
 watch(selectedFormatId, () => {
   formData.value = {}
+  // Initialize default values for select fields
+  if (selectedFormat.value) {
+    selectedFormat.value.fields.forEach(field => {
+      if (field.type === 'select' && field.options && field.options.length > 0) {
+        formData.value[field.id] = field.options[0]
+      }
+    })
+  }
 })
 
 const handleSubmit = (event: Event) => {
@@ -46,6 +61,14 @@ function validateInput() {
 
 function cleanInput() {
   formData.value = {}
+  // Re-initialize default values for select fields
+  if (selectedFormat.value) {
+    selectedFormat.value.fields.forEach(field => {
+      if (field.type === 'select' && field.options && field.options.length > 0) {
+        formData.value[field.id] = field.options[0]
+      }
+    })
+  }
 }
 </script>
 
@@ -54,11 +77,10 @@ function cleanInput() {
     
     <div class="form-group" v-if="availableFormats.length > 1">
       <label class="form-label">Formato</label>
-      <select class="input-element select-element" v-model="selectedFormatId">
-        <option v-for="format in availableFormats" :key="format.id" :value="format.id">
-          {{ format.name }}
-        </option>
-      </select>
+      <CustomSelect 
+        v-model="selectedFormatId" 
+        :options="formatOptions" 
+      />
     </div>
 
     <template v-if="selectedFormat">
@@ -66,7 +88,15 @@ function cleanInput() {
         <label class="form-label">
            {{ field.label.includes('.') ? $t(field.label) : field.label }}
         </label>
+        
+        <CustomSelect
+          v-if="field.type === 'select' && field.options"
+          v-model="formData[field.id]"
+          :options="field.options.map(opt => ({ value: opt, label: opt }))"
+          :name="field.id"
+        />
         <input
+          v-else
           class="input-element"
           type="text"
           :name="field.id"
@@ -105,16 +135,6 @@ function cleanInput() {
 
 .input-element {
   width: 100%;
-}
-
-.select-element {
-  background-color: var(--bg-surface);
-  color: var(--text-main);
-  border: 1px solid var(--border-color);
-  border-radius: 6px;
-  padding: 0.75rem 1rem;
-  font-size: 1rem;
-  appearance: auto;
 }
 
 .generate-btn {

--- a/src/components/BranchForm.vue
+++ b/src/components/BranchForm.vue
@@ -1,11 +1,14 @@
 <script setup lang="ts">
 import { ref, watch, onMounted, computed } from 'vue'
+import { useI18n } from 'vue-i18n'
 import type { BranchFormType } from '@/core/BranchTypes'
 import type { BranchFormatTemplate } from '@/core/FormatTypes'
 import { FormatManager } from '@/core/FormatManager'
 import CustomSelect from '@/components/CustomSelect.vue'
 
 const emit = defineEmits(['submitForm'])
+
+const { t } = useI18n()
 
 const availableFormats = ref<BranchFormatTemplate[]>([])
 const selectedFormatId = ref<string>('')
@@ -25,7 +28,7 @@ const selectedFormat = computed(() => {
 })
 
 const formatOptions = computed(() => {
-  return availableFormats.value.map(f => ({ value: f.id, label: f.name }))
+  return availableFormats.value.map(f => ({ value: f.id, label: f.name.includes('.') ? t(f.name) : f.name }))
 })
 
 watch(selectedFormatId, () => {
@@ -73,10 +76,10 @@ function cleanInput() {
 </script>
 
 <template>
-  <form class="form" aria-label="Create branch name form" @submit="handleSubmit">
+  <form class="form" :aria-label="$t('form.generate')" @submit="handleSubmit">
     
     <div class="form-group" v-if="availableFormats.length > 1">
-      <label class="form-label">Formato</label>
+      <label class="form-label">{{ $t('form.formatLabel') }}</label>
       <CustomSelect 
         v-model="selectedFormatId" 
         :options="formatOptions" 

--- a/src/components/BranchItem.vue
+++ b/src/components/BranchItem.vue
@@ -4,8 +4,8 @@
       <p class="branch__name__text">{{ props.branchName }}</p>
     </div>
     <div class="branch__buttons">
-      <button class="branch__button branch__button__copy" @click="copyToClipboard">Copy</button>
-      <button class="branch__button branch__button__delete" @click="deleteBranch">Delete</button>
+      <button class="branch__button branch__button__copy" @click="copyToClipboard">{{ $t('history.copy') }}</button>
+      <button class="branch__button branch__button__delete" @click="deleteBranch">{{ $t('history.delete') }}</button>
     </div>
   </div>
 </template>

--- a/src/components/BranchItem.vue
+++ b/src/components/BranchItem.vue
@@ -36,11 +36,10 @@ const deleteBranch = () => {
   border: 1px solid var(--border-color);
   border-radius: 8px;
   padding: 10px 20px;
-  margin-bottom: 0.75rem;
   color: var(--text-main);
   transition: all 0.2s;
 
-  @media (max-width: 768px) {
+  @media (max-width: vars.$bp-mobile) {
     padding: 10px 15px;
     flex-direction: column;
     gap: 10px;
@@ -54,7 +53,7 @@ const deleteBranch = () => {
     flex: 1;
     min-width: 0;
 
-    @media (max-width: 768px) {
+    @media (max-width: vars.$bp-mobile) {
       width: 100%;
       text-align: center;
     }
@@ -73,7 +72,7 @@ const deleteBranch = () => {
     display: flex;
     gap: 0.5rem;
 
-    @media (max-width: 768px) {
+    @media (max-width: vars.$bp-mobile) {
       width: 100%;
       justify-content: center;
     }

--- a/src/components/BranchList.vue
+++ b/src/components/BranchList.vue
@@ -25,4 +25,18 @@ const handleDeleteBranch = (branchId: number) => {
   </section>
 </template>
 
-<style scoped></style>
+<style scoped lang="scss">
+.branch_list {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+@media (min-width: vars.$bp-tablet) {
+  .branch_list {
+    display: grid;
+    grid-template-columns: repeat(auto-fill, minmax(320px, 1fr));
+    gap: 0.75rem;
+  }
+}
+</style>

--- a/src/components/CookieBanner.vue
+++ b/src/components/CookieBanner.vue
@@ -72,7 +72,7 @@ const handleDecline = () => {
     gap: 1rem;
   }
 
-  @media (min-width: 640px) {
+  @media (min-width: vars.$bp-mobile) {
     &__content {
       flex-direction: row;
       align-items: center;

--- a/src/components/CustomModal.vue
+++ b/src/components/CustomModal.vue
@@ -1,0 +1,139 @@
+<script setup lang="ts">
+import { onMounted, onUnmounted } from 'vue';
+
+const props = defineProps<{
+  modelValue: boolean;
+  title: string;
+  message: string;
+  confirmText?: string;
+  cancelText?: string;
+  danger?: boolean;
+}>();
+
+const emit = defineEmits<{
+  (e: 'update:modelValue', value: boolean): void;
+  (e: 'confirm'): void;
+  (e: 'cancel'): void;
+}>();
+
+const handleClose = () => {
+  emit('update:modelValue', false);
+  emit('cancel');
+};
+
+const handleConfirm = () => {
+  emit('update:modelValue', false);
+  emit('confirm');
+};
+
+const handleKeydown = (e: KeyboardEvent) => {
+  if (props.modelValue && e.key === 'Escape') {
+    handleClose();
+  }
+};
+
+onMounted(() => {
+  document.addEventListener('keydown', handleKeydown);
+});
+
+onUnmounted(() => {
+  document.removeEventListener('keydown', handleKeydown);
+});
+</script>
+
+<template>
+  <transition name="modal-fade">
+    <div v-if="modelValue" class="modal-overlay" @click.self="handleClose">
+      <div class="modal-content" role="dialog" aria-modal="true" :aria-labelledby="'modal-title'">
+        <h3 id="modal-title" class="modal-title">{{ title }}</h3>
+        <p class="modal-message">{{ message }}</p>
+        
+        <div class="modal-actions">
+          <button type="button" class="btn-secondary" @click="handleClose">
+            {{ cancelText || $t('cancel') || 'Cancelar' }}
+          </button>
+          <button 
+            type="button" 
+            :class="danger ? 'btn-danger' : 'btn-primary'" 
+            @click="handleConfirm"
+          >
+            {{ confirmText || $t('confirm') || 'Confirmar' }}
+          </button>
+        </div>
+      </div>
+    </div>
+  </transition>
+</template>
+
+<style scoped lang="scss">
+.modal-overlay {
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  background-color: rgba(0, 0, 0, 0.5);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 9999;
+  backdrop-filter: blur(2px);
+}
+
+.modal-content {
+  background-color: var(--bg-surface);
+  border-radius: 12px;
+  padding: 1.5rem;
+  width: 90%;
+  max-width: 400px;
+  box-shadow: 0 10px 25px rgba(0, 0, 0, 0.2);
+  border: 1px solid var(--border-color);
+}
+
+.modal-title {
+  margin-top: 0;
+  margin-bottom: 1rem;
+  font-size: 1.25rem;
+  color: var(--text-main);
+}
+
+.modal-message {
+  color: var(--text-muted);
+  margin-bottom: 1.5rem;
+  line-height: 1.5;
+}
+
+.modal-actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 0.75rem;
+}
+
+.btn-danger {
+  background-color: #e74c3c;
+  color: white;
+  border: none;
+  border-radius: 8px;
+  padding: 0.6rem 1.2rem;
+  font-weight: 600;
+  font-size: 0.9rem;
+  cursor: pointer;
+  transition: all 0.2s ease;
+}
+
+.btn-danger:hover {
+  background-color: #c0392b;
+}
+
+/* Animations */
+.modal-fade-enter-active,
+.modal-fade-leave-active {
+  transition: opacity 0.2s ease, transform 0.2s ease;
+}
+
+.modal-fade-enter-from,
+.modal-fade-leave-to {
+  opacity: 0;
+  transform: scale(0.95);
+}
+</style>

--- a/src/components/CustomModal.vue
+++ b/src/components/CustomModal.vue
@@ -50,14 +50,14 @@ onUnmounted(() => {
         
         <div class="modal-actions">
           <button type="button" class="btn-secondary" @click="handleClose">
-            {{ cancelText || $t('cancel') || 'Cancelar' }}
+            {{ cancelText || $t('common.cancel') }}
           </button>
-          <button 
-            type="button" 
-            :class="danger ? 'btn-danger' : 'btn-primary'" 
+          <button
+            type="button"
+            :class="danger ? 'btn-danger' : 'btn-primary'"
             @click="handleConfirm"
           >
-            {{ confirmText || $t('confirm') || 'Confirmar' }}
+            {{ confirmText || $t('common.confirm') }}
           </button>
         </div>
       </div>

--- a/src/components/CustomSelect.vue
+++ b/src/components/CustomSelect.vue
@@ -1,0 +1,309 @@
+<script setup lang="ts">
+import { ref, computed, onMounted, onUnmounted, nextTick } from 'vue';
+
+const props = withDefaults(defineProps<{
+  modelValue: string;
+  options: { value: string; label: string }[];
+  placeholder?: string;
+  id?: string;
+  name?: string;
+  size?: 'md' | 'sm';
+  disabled?: boolean;
+}>(), {
+  size: 'md',
+  disabled: false
+});
+
+const emit = defineEmits<{
+  (e: 'update:modelValue', value: string): void;
+}>();
+
+const isOpen = ref(false);
+const containerRef = ref<HTMLElement | null>(null);
+const triggerRef = ref<HTMLButtonElement | null>(null);
+const optionRefs = ref<HTMLButtonElement[]>([]);
+
+const currentLabel = computed(() => {
+  const found = props.options.find(opt => opt.value === props.modelValue);
+  return found ? found.label : (props.placeholder || 'Selecciona una opción');
+});
+
+const setOptionRef = (el: any, index: number) => {
+  if (el) optionRefs.value[index] = el as HTMLButtonElement;
+};
+
+const openDropdown = async () => {
+  isOpen.value = true;
+  await nextTick();
+  const selectedIndex = props.options.findIndex(opt => opt.value === props.modelValue);
+  optionRefs.value[selectedIndex >= 0 ? selectedIndex : 0]?.focus();
+};
+
+const closeDropdown = (returnFocus = true) => {
+  isOpen.value = false;
+  if (returnFocus) triggerRef.value?.focus();
+};
+
+const toggleDropdown = () => {
+  if (props.disabled) return;
+  if (isOpen.value) {
+    closeDropdown(false);
+  } else {
+    openDropdown();
+  }
+};
+
+const selectOption = (value: string) => {
+  emit('update:modelValue', value);
+  closeDropdown();
+};
+
+const focusOptionByOffset = (currentIndex: number, offset: number) => {
+  const count = props.options.length;
+  if (count === 0) return;
+  const nextIndex = (currentIndex + offset + count) % count;
+  optionRefs.value[nextIndex]?.focus();
+};
+
+const handleOptionKeydown = (event: KeyboardEvent, index: number) => {
+  switch (event.key) {
+    case 'ArrowDown':
+      event.preventDefault();
+      focusOptionByOffset(index, 1);
+      break;
+    case 'ArrowUp':
+      event.preventDefault();
+      focusOptionByOffset(index, -1);
+      break;
+    case 'Home':
+      event.preventDefault();
+      optionRefs.value[0]?.focus();
+      break;
+    case 'End':
+      event.preventDefault();
+      optionRefs.value[props.options.length - 1]?.focus();
+      break;
+    case 'Escape':
+      event.preventDefault();
+      closeDropdown();
+      break;
+    case 'Tab':
+      closeDropdown(false);
+      break;
+  }
+};
+
+const handleTriggerKeydown = (event: KeyboardEvent) => {
+  if (props.disabled) return;
+  if (event.key === 'ArrowDown' || event.key === 'ArrowUp') {
+    event.preventDefault();
+    openDropdown();
+  }
+};
+
+const handleClickOutside = (event: MouseEvent) => {
+  if (containerRef.value && !containerRef.value.contains(event.target as Node)) {
+    isOpen.value = false;
+  }
+};
+
+onMounted(() => {
+  document.addEventListener('click', handleClickOutside);
+});
+
+onUnmounted(() => {
+  document.removeEventListener('click', handleClickOutside);
+});
+</script>
+
+<template>
+  <div class="custom-select-container" ref="containerRef" :id="id">
+    <!-- input oculto para compatibilidad con forms -->
+    <input type="hidden" :name="name" :value="modelValue" />
+
+    <button
+      ref="triggerRef"
+      type="button"
+      class="custom-select-trigger"
+      :class="{ 'custom-select-trigger--sm': size === 'sm' }"
+      :disabled="disabled"
+      @click="toggleDropdown"
+      @keydown="handleTriggerKeydown"
+      aria-haspopup="listbox"
+      :aria-expanded="isOpen"
+    >
+      <span class="select-label" :class="{ 'placeholder': !modelValue && placeholder }">{{ currentLabel }}</span>
+      <span class="dropdown-arrow" :class="{ 'arrow-open': isOpen }" aria-hidden="true">▾</span>
+    </button>
+
+    <transition name="fade-slide">
+      <ul v-if="isOpen" class="custom-select-dropdown" role="listbox">
+        <li
+          v-for="(opt, index) in options"
+          :key="opt.value"
+          role="presentation"
+        >
+          <button
+            type="button"
+            :ref="(el) => setOptionRef(el, index)"
+            class="select-option"
+            :class="{ 'option-selected': opt.value === modelValue }"
+            role="option"
+            :aria-selected="opt.value === modelValue"
+            :tabindex="opt.value === modelValue ? 0 : -1"
+            @click="selectOption(opt.value)"
+            @keydown="handleOptionKeydown($event, index)"
+          >
+            <span>{{ opt.label }}</span>
+          </button>
+        </li>
+      </ul>
+    </transition>
+  </div>
+</template>
+
+<style scoped lang="scss">
+.custom-select-container {
+  position: relative;
+  display: block; /* Make it full width block like standard inputs */
+  width: 100%;
+}
+
+.custom-select-trigger {
+  width: 100%;
+  background: var(--bg-body);
+  border: 1px solid var(--border-color);
+  color: var(--text-main);
+  padding: vars.$control-padding-y vars.$control-padding-x;
+  border-radius: 8px;
+  cursor: pointer;
+  font-size: vars.$control-font-size;
+  font-family: inherit;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  transition: all 0.2s ease-in-out;
+  text-align: left;
+  box-shadow: 0 1px 2px rgba(0, 0, 0, 0.05);
+
+  &--sm {
+    padding: vars.$control-padding-y-sm vars.$control-padding-x-sm;
+    font-size: vars.$control-font-size-sm;
+  }
+}
+
+.custom-select-trigger:focus,
+.custom-select-trigger:focus-visible {
+  outline: none;
+  border-color: var(--accent-color);
+  box-shadow: 0 0 0 3px var(--accent-color-alpha);
+}
+
+.custom-select-trigger:hover {
+  border-color: var(--text-muted);
+}
+
+.custom-select-trigger:disabled {
+  cursor: not-allowed;
+  opacity: 0.65;
+
+  &:hover {
+    border-color: var(--border-color);
+  }
+}
+
+.placeholder {
+  color: var(--text-muted);
+}
+
+.select-label {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.dropdown-arrow {
+  font-size: 0.8rem;
+  color: var(--text-muted);
+  transition: transform 0.2s ease;
+  margin-left: 0.5rem;
+}
+
+.arrow-open {
+  transform: rotate(180deg);
+}
+
+.custom-select-dropdown {
+  position: absolute;
+  top: calc(100% + 0.35rem);
+  left: 0;
+  width: 100%;
+  background-color: var(--bg-surface);
+  border: 1px solid var(--border-color);
+  border-radius: 8px;
+  box-shadow: 0 4px 12px -2px rgba(0, 0, 0, 0.08), 0 2px 6px -1px rgba(0, 0, 0, 0.04);
+  padding: 0.35rem 0;
+  max-height: 250px;
+  overflow-y: auto;
+  list-style: none;
+  z-index: 2000;
+  margin: 0;
+}
+
+.select-option {
+  display: flex;
+  align-items: center;
+  width: 100%;
+  padding: 0.6rem 1rem;
+  font-size: 0.95rem;
+  font-weight: 500;
+  font-family: inherit;
+  color: var(--text-main);
+  background: transparent;
+  border: none;
+  cursor: pointer;
+  transition: background-color 0.15s;
+  text-align: left;
+}
+
+.select-option:hover,
+.select-option:focus-visible {
+  background-color: var(--bg-surface-hover);
+  outline: none;
+}
+
+.option-selected {
+  background-color: var(--accent-color);
+  color: var(--bg-body);
+}
+
+.option-selected:hover,
+.option-selected:focus-visible {
+  background-color: var(--accent-color);
+  color: var(--bg-body);
+}
+
+/* Animations */
+.fade-slide-enter-active,
+.fade-slide-leave-active {
+  transition: all 0.15s cubic-bezier(0.16, 1, 0.3, 1);
+}
+
+.fade-slide-enter-from {
+  opacity: 0;
+  transform: translateY(-0.25rem);
+}
+
+.fade-slide-leave-to {
+  opacity: 0;
+  transform: translateY(-0.25rem);
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .fade-slide-enter-active,
+  .fade-slide-leave-active,
+  .dropdown-arrow {
+    transition: none;
+  }
+}
+</style>

--- a/src/components/Footer.vue
+++ b/src/components/Footer.vue
@@ -6,7 +6,18 @@ const appVersion = __APP_VERSION__
   <footer class="footer">
     <div class="footer__content">
       <p class="footer__text">
-        {{ $t('footer.privacy') }} <span class="footer__version">• v{{ appVersion }}</span>
+        {{ $t('footer.privacy') }}
+        <span class="footer__version">
+          •
+          <a
+            :href="`https://github.com/jnfire/web-branch-name-formatter/releases/tag/v${appVersion}`"
+            target="_blank"
+            rel="noopener noreferrer"
+            class="footer__version-link"
+          >
+            v{{ appVersion }}
+          </a>
+        </span>
       </p>
       <div class="footer__links">
         <a
@@ -49,6 +60,17 @@ const appVersion = __APP_VERSION__
 
   &__version {
     opacity: 0.8;
+  }
+
+  &__version-link {
+    color: inherit;
+    text-decoration: none;
+    transition: opacity 0.2s;
+
+    &:hover {
+      text-decoration: underline;
+      opacity: 1;
+    }
   }
 
   &__links {

--- a/src/components/Footer.vue
+++ b/src/components/Footer.vue
@@ -1,8 +1,12 @@
+<script setup lang="ts">
+const appVersion = __APP_VERSION__
+</script>
+
 <template>
   <footer class="footer">
     <div class="footer__content">
       <p class="footer__text">
-        {{ $t('footer.privacy') }}
+        {{ $t('footer.privacy') }} <span class="footer__version">• v{{ appVersion }}</span>
       </p>
       <div class="footer__links">
         <a
@@ -41,6 +45,10 @@
     color: var(--text-muted);
     font-size: 0.9rem;
     margin-bottom: 1rem;
+  }
+
+  &__version {
+    opacity: 0.8;
   }
 
   &__links {

--- a/src/components/FormatEditor.vue
+++ b/src/components/FormatEditor.vue
@@ -1,0 +1,180 @@
+<script setup lang="ts">
+import { ref, watch } from 'vue'
+import type { BranchFormatTemplate, FieldDefinition, FormatOperation } from '@/core/FormatTypes'
+
+const props = defineProps<{
+  format: BranchFormatTemplate
+}>()
+
+const emit = defineEmits(['save', 'cancel'])
+
+const localFormat = ref<BranchFormatTemplate>(JSON.parse(JSON.stringify(props.format)))
+
+const availableOperations: { value: FormatOperation; label: string }[] = [
+  { value: 'UPPERCASE', label: 'Mayúsculas' },
+  { value: 'LOWERCASE', label: 'Minúsculas' },
+  { value: 'REPLACE_SLASHES', label: 'Reemplazar "/" por "-o-"' },
+  { value: 'REPLACE_DOTS', label: 'Reemplazar "." por "-"' },
+  { value: 'REPLACE_SPACES', label: 'Reemplazar espacios por "-"' },
+  { value: 'REMOVE_MULTIPLE_DASHES', label: 'Quitar guiones múltiples' },
+  { value: 'SET_NY', label: 'Cambiar "ñ" por "ny"' },
+  { value: 'REMOVE_ACCENTS', label: 'Quitar tildes' },
+  { value: 'REMOVE_SPECIAL_CHARS', label: 'Quitar caracteres especiales' },
+  { value: 'BASIC_CLEAN', label: 'Limpieza Básica' },
+]
+
+watch(() => props.format, (newFormat) => {
+  localFormat.value = JSON.parse(JSON.stringify(newFormat))
+}, { deep: true })
+
+// Actualizamos la prop 'format' original si cambia localFormat (para previsualización en vivo)
+// No mutamos props, emitimos un update o el padre le pasa el mismo ref que está editando.
+// En este caso, emitiremos update:format para que el padre actualice la previsualización
+watch(localFormat, (newVal) => {
+  emit('update:format', newVal)
+}, { deep: true })
+
+const addField = () => {
+  const newId = `campo${localFormat.value.fields.length + 1}`
+  localFormat.value.fields.push({
+    id: newId,
+    label: `Nuevo Campo`,
+    operations: []
+  })
+}
+
+const removeField = (index: number) => {
+  localFormat.value.fields.splice(index, 1)
+}
+
+const handleSave = () => {
+  emit('save', localFormat.value)
+}
+
+const toggleOperation = (field: FieldDefinition, op: FormatOperation) => {
+  const index = field.operations.indexOf(op)
+  if (index === -1) {
+    field.operations.push(op)
+  } else {
+    field.operations.splice(index, 1)
+  }
+}
+</script>
+
+<template>
+  <div class="editor">
+    <div class="form-group">
+      <label class="form-label">Nombre del formato</label>
+      <input type="text" v-model="localFormat.name" class="input-element" />
+    </div>
+    
+    <div class="form-group">
+      <label class="form-label">Plantilla (Usa {id} para inyectar campos)</label>
+      <input type="text" v-model="localFormat.templateString" class="input-element" />
+    </div>
+
+    <div class="fields-section">
+      <h4 class="form-label">Campos</h4>
+      <div v-for="(field, index) in localFormat.fields" :key="index" class="field-editor">
+        <div class="field-header">
+          <input type="text" v-model="field.id" placeholder="ID (ej: ticketId)" class="input-element small" />
+          <input type="text" v-model="field.label" placeholder="Etiqueta UI" class="input-element small" />
+          <button @click="removeField(index)" class="btn-secondary small-btn" title="Eliminar campo">X</button>
+        </div>
+        <div class="operations-list">
+          <label v-for="op in availableOperations" :key="op.value" class="op-label">
+            <input 
+              type="checkbox" 
+              :checked="field.operations.includes(op.value)"
+              @change="toggleOperation(field, op.value)"
+            />
+            {{ op.label }}
+          </label>
+        </div>
+      </div>
+      <button @click="addField" class="btn-secondary">+ Añadir Campo</button>
+    </div>
+
+    <div class="actions">
+      <button @click="emit('cancel')" class="btn-secondary">Cancelar</button>
+      <button @click="handleSave" class="btn-primary">Guardar</button>
+    </div>
+  </div>
+</template>
+
+<style scoped lang="scss">
+.editor {
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+}
+
+.form-group {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.form-label {
+  font-size: 0.85rem;
+  font-weight: 600;
+  color: var(--text-muted);
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+}
+
+.input-element {
+  width: 100%;
+  &.small {
+    padding: 0.5rem;
+    font-size: 0.9rem;
+  }
+}
+
+.fields-section {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  border-top: 1px solid var(--border-color);
+  padding-top: 1.5rem;
+}
+
+.field-editor {
+  background-color: var(--bg-surface);
+  border: 1px solid var(--border-color);
+  border-radius: 8px;
+  padding: 1rem;
+}
+
+.field-header {
+  display: flex;
+  gap: 0.5rem;
+  margin-bottom: 1rem;
+}
+
+.small-btn {
+  padding: 0 0.75rem;
+}
+
+.operations-list {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(200px, 1fr));
+  gap: 0.5rem;
+}
+
+.op-label {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  font-size: 0.85rem;
+  color: var(--text-main);
+  cursor: pointer;
+}
+
+.actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 1rem;
+  margin-top: 1rem;
+}
+</style>

--- a/src/components/FormatEditor.vue
+++ b/src/components/FormatEditor.vue
@@ -1,35 +1,35 @@
 <script setup lang="ts">
 import { ref, watch } from 'vue'
-import type { BranchFormatTemplate, FieldDefinition, FormatOperation } from '@/core/FormatTypes'
+import type { BranchFormatTemplate, Capitalization, FieldDefinition, LanguageProfile } from '@/core/FormatTypes'
+import CustomSelect from '@/components/CustomSelect.vue'
 
 const props = defineProps<{
   format: BranchFormatTemplate
 }>()
 
-const emit = defineEmits(['save', 'cancel'])
+const emit = defineEmits(['save', 'cancel', 'update:format', 'toggle-visibility'])
 
 const localFormat = ref<BranchFormatTemplate>(JSON.parse(JSON.stringify(props.format)))
 
-const availableOperations: { value: FormatOperation; label: string }[] = [
+const capitalizationOptions: { value: Capitalization; label: string }[] = [
   { value: 'UPPERCASE', label: 'Mayúsculas' },
   { value: 'LOWERCASE', label: 'Minúsculas' },
-  { value: 'REPLACE_SLASHES', label: 'Reemplazar "/" por "-o-"' },
-  { value: 'REPLACE_DOTS', label: 'Reemplazar "." por "-"' },
-  { value: 'REPLACE_SPACES', label: 'Reemplazar espacios por "-"' },
-  { value: 'REMOVE_MULTIPLE_DASHES', label: 'Quitar guiones múltiples' },
-  { value: 'SET_NY', label: 'Cambiar "ñ" por "ny"' },
-  { value: 'REMOVE_ACCENTS', label: 'Quitar tildes' },
-  { value: 'REMOVE_SPECIAL_CHARS', label: 'Quitar caracteres especiales' },
-  { value: 'BASIC_CLEAN', label: 'Limpieza Básica' },
+  { value: 'AS_IS', label: 'Tal cual' }
+]
+
+const languageOptions: { value: LanguageProfile; label: string }[] = [
+  { value: 'es', label: 'Español' },
+  { value: 'en', label: 'English' },
+  { value: 'fr', label: 'Français' },
+  { value: 'de', label: 'Deutsch' },
+  { value: 'it', label: 'Italiano' },
+  { value: 'pt', label: 'Português' }
 ]
 
 watch(() => props.format, (newFormat) => {
   localFormat.value = JSON.parse(JSON.stringify(newFormat))
 }, { deep: true })
 
-// Actualizamos la prop 'format' original si cambia localFormat (para previsualización en vivo)
-// No mutamos props, emitimos un update o el padre le pasa el mismo ref que está editando.
-// En este caso, emitiremos update:format para que el padre actualice la previsualización
 watch(localFormat, (newVal) => {
   emit('update:format', newVal)
 }, { deep: true })
@@ -39,7 +39,8 @@ const addField = () => {
   localFormat.value.fields.push({
     id: newId,
     label: `Nuevo Campo`,
-    operations: []
+    capitalization: 'AS_IS',
+    type: 'text'
   })
 }
 
@@ -51,53 +52,115 @@ const handleSave = () => {
   emit('save', localFormat.value)
 }
 
-const toggleOperation = (field: FieldDefinition, op: FormatOperation) => {
-  const index = field.operations.indexOf(op)
-  if (index === -1) {
-    field.operations.push(op)
-  } else {
-    field.operations.splice(index, 1)
-  }
+const updateOptions = (field: FieldDefinition, event: Event) => {
+  const val = (event.target as HTMLInputElement).value;
+  field.options = val.split(',').map(s => s.trim()).filter(Boolean);
 }
 </script>
 
 <template>
   <div class="editor">
+    <div class="status-section">
+      <button
+        type="button"
+        class="switch"
+        :class="{ 'switch--on': format.isVisible }"
+        role="switch"
+        :aria-checked="format.isVisible"
+        @click="emit('toggle-visibility')"
+      >
+        <span class="switch-track"><span class="switch-thumb"></span></span>
+        <span class="switch-label">{{ format.isVisible ? 'Activado' : 'Desactivado' }}</span>
+      </button>
+      <p class="switch-hint">
+        {{ format.isVisible
+          ? 'Este formato aparece como opción en el formulario principal.'
+          : 'Este formato está oculto: no aparecerá como opción en el formulario principal.' }}
+      </p>
+    </div>
+
+    <p v-if="format.isReadonly" class="readonly-hint">
+      Este formato viene incluido en la app y no se puede modificar. Para personalizarlo, clónalo desde la lista y edita la copia.
+    </p>
+
     <div class="form-group">
       <label class="form-label">Nombre del formato</label>
-      <input type="text" v-model="localFormat.name" class="input-element" />
+      <input type="text" v-model="localFormat.name" class="input-element" :disabled="format.isReadonly" />
     </div>
-    
+
     <div class="form-group">
       <label class="form-label">Plantilla (Usa {id} para inyectar campos)</label>
-      <input type="text" v-model="localFormat.templateString" class="input-element" />
+      <input type="text" v-model="localFormat.templateString" class="input-element" :disabled="format.isReadonly" />
+    </div>
+
+    <div class="form-group">
+      <label class="form-label">Idioma (saneado de caracteres: ñ, /, tildes...)</label>
+      <CustomSelect v-model="localFormat.language" :options="languageOptions" :disabled="format.isReadonly" />
     </div>
 
     <div class="fields-section">
       <h4 class="form-label">Campos</h4>
       <div v-for="(field, index) in localFormat.fields" :key="index" class="field-editor">
-        <div class="field-header">
-          <input type="text" v-model="field.id" placeholder="ID (ej: ticketId)" class="input-element small" />
-          <input type="text" v-model="field.label" placeholder="Etiqueta UI" class="input-element small" />
-          <button @click="removeField(index)" class="btn-secondary small-btn" title="Eliminar campo">X</button>
+        <div class="field-editor-head">
+          <span class="field-index">Campo {{ index + 1 }}</span>
+          <button v-if="!format.isReadonly" @click="removeField(index)" class="icon-btn delete-btn" title="Eliminar campo">
+            <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M3 6h18"></path><path d="M19 6v14c0 1-1 2-2 2H7c-1 0-2-1-2-2V6"></path><path d="M8 6V4c0-1 1-2 2-2h4c1 0 2 1 2 2v2"></path></svg>
+          </button>
         </div>
-        <div class="operations-list">
-          <label v-for="op in availableOperations" :key="op.value" class="op-label">
-            <input 
-              type="checkbox" 
-              :checked="field.operations.includes(op.value)"
-              @change="toggleOperation(field, op.value)"
+
+        <div class="field-header">
+          <div class="field-control">
+            <label class="field-label-small">ID del Campo</label>
+            <input type="text" v-model="field.id" placeholder="ej: ticketId" class="input-element small" :disabled="format.isReadonly" />
+          </div>
+
+          <div class="field-control">
+            <label class="field-label-small">Nombre del Campo</label>
+            <input type="text" v-model="field.label" placeholder="ej: ID Ticket" class="input-element small" :disabled="format.isReadonly" />
+          </div>
+
+          <div class="field-control type-select">
+            <label class="field-label-small">Tipo</label>
+            <CustomSelect
+              v-model="field.type"
+              size="sm"
+              :disabled="format.isReadonly"
+              :options="[{value: 'text', label: 'Texto Libre'}, {value: 'select', label: 'Selector'}]"
             />
-            {{ op.label }}
-          </label>
+          </div>
+
+          <div class="field-control type-select">
+            <label class="field-label-small">Capitalización</label>
+            <CustomSelect
+              v-model="field.capitalization"
+              size="sm"
+              :disabled="format.isReadonly"
+              :options="capitalizationOptions"
+            />
+          </div>
+        </div>
+
+        <div v-if="field.type === 'select'" class="field-options-control">
+          <label class="field-label-small">Opciones (separadas por comas)</label>
+          <input
+            type="text"
+            :value="(field.options || []).join(', ')"
+            @input="updateOptions(field, $event)"
+            placeholder="ej: feature, fix, hotfix"
+            class="input-element small"
+            :disabled="format.isReadonly"
+          />
         </div>
       </div>
-      <button @click="addField" class="btn-secondary">+ Añadir Campo</button>
+      <button v-if="!format.isReadonly" @click="addField" class="btn-secondary">+ Añadir Campo</button>
     </div>
 
     <div class="actions">
-      <button @click="emit('cancel')" class="btn-secondary">Cancelar</button>
-      <button @click="handleSave" class="btn-primary">Guardar</button>
+      <button v-if="format.isReadonly" @click="emit('cancel')" class="btn-secondary">Cerrar</button>
+      <template v-else>
+        <button @click="emit('cancel')" class="btn-secondary">Cancelar</button>
+        <button @click="handleSave" class="btn-primary">Guardar</button>
+      </template>
     </div>
   </div>
 </template>
@@ -115,6 +178,79 @@ const toggleOperation = (field: FieldDefinition, op: FormatOperation) => {
   gap: 0.5rem;
 }
 
+.status-section {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 0.5rem;
+  padding-bottom: 1.5rem;
+  border-bottom: 1px solid var(--border-color);
+}
+
+.switch-hint {
+  font-size: 0.8rem;
+  color: var(--text-muted);
+  line-height: 1.4;
+}
+
+.switch {
+  display: flex;
+  align-items: center;
+  gap: 0.6rem;
+  background: none;
+  border: none;
+  padding: 0;
+  cursor: pointer;
+  font-size: 0.9rem;
+  font-weight: 500;
+  color: var(--text-main);
+  font-family: inherit;
+}
+
+.switch-track {
+  position: relative;
+  width: 38px;
+  height: 22px;
+  flex-shrink: 0;
+  border-radius: 9999px;
+  background-color: var(--border-color);
+  transition: background-color 0.2s ease;
+}
+
+.switch-thumb {
+  position: absolute;
+  top: 2px;
+  left: 2px;
+  width: 18px;
+  height: 18px;
+  border-radius: 50%;
+  background-color: var(--bg-body);
+  box-shadow: 0 1px 2px rgba(0, 0, 0, 0.15);
+  transition: transform 0.2s ease;
+}
+
+.switch--on .switch-track {
+  background-color: var(--accent-color);
+}
+
+.switch--on .switch-thumb {
+  transform: translateX(16px);
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .switch-track,
+  .switch-thumb {
+    transition: none;
+  }
+}
+
+.readonly-hint {
+  font-size: 0.85rem;
+  color: var(--text-muted);
+  line-height: 1.5;
+  margin-top: -0.5rem;
+}
+
 .form-label {
   font-size: 0.85rem;
   font-weight: 600;
@@ -126,8 +262,14 @@ const toggleOperation = (field: FieldDefinition, op: FormatOperation) => {
 .input-element {
   width: 100%;
   &.small {
-    padding: 0.5rem;
-    font-size: 0.9rem;
+    padding: vars.$control-padding-y-sm vars.$control-padding-x-sm;
+    font-size: vars.$control-font-size-sm;
+  }
+
+  &:disabled {
+    cursor: not-allowed;
+    opacity: 0.65;
+    background-color: var(--bg-surface);
   }
 }
 
@@ -146,29 +288,51 @@ const toggleOperation = (field: FieldDefinition, op: FormatOperation) => {
   padding: 1rem;
 }
 
+.field-editor-head {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 0.75rem;
+}
+
+.field-index {
+  font-size: 0.8rem;
+  font-weight: 600;
+  color: var(--text-muted);
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+}
+
 .field-header {
   display: flex;
-  gap: 0.5rem;
+  flex-wrap: wrap;
+  gap: 0.75rem;
   margin-bottom: 1rem;
+  align-items: flex-end;
 }
 
-.small-btn {
-  padding: 0 0.75rem;
-}
-
-.operations-list {
-  display: grid;
-  grid-template-columns: repeat(auto-fill, minmax(200px, 1fr));
-  gap: 0.5rem;
-}
-
-.op-label {
+.field-control {
+  flex: 1 1 160px;
   display: flex;
-  align-items: center;
-  gap: 0.5rem;
-  font-size: 0.85rem;
-  color: var(--text-main);
-  cursor: pointer;
+  flex-direction: column;
+  gap: 0.25rem;
+}
+
+.field-options-control {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+  margin-bottom: 1rem;
+  background-color: var(--bg-body);
+  padding: 0.75rem;
+  border-radius: 8px;
+  border: 1px dashed var(--border-color);
+}
+
+.field-label-small {
+  font-size: 0.75rem;
+  font-weight: 500;
+  color: var(--text-muted);
 }
 
 .actions {
@@ -176,5 +340,35 @@ const toggleOperation = (field: FieldDefinition, op: FormatOperation) => {
   justify-content: flex-end;
   gap: 1rem;
   margin-top: 1rem;
+}
+
+.icon-btn {
+  background: none;
+  border: none;
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0.5rem;
+  border-radius: 8px;
+  transition: background-color 0.2s;
+}
+
+.delete-btn {
+  color: var(--error-color);
+}
+
+.delete-btn:hover {
+  background-color: rgba(239, 68, 68, 0.1);
+}
+
+@media (max-width: vars.$bp-mobile) {
+  .field-header {
+    flex-direction: column;
+    align-items: stretch;
+  }
+  .field-control {
+    flex-basis: auto;
+  }
 }
 </style>

--- a/src/components/FormatEditor.vue
+++ b/src/components/FormatEditor.vue
@@ -160,7 +160,8 @@ const updateOptions = (field: FieldDefinition, event: Event) => {
           <div class="field-control type-select">
             <label class="field-label-small">{{ $t('configurator.editor.type') }}</label>
             <CustomSelect
-              v-model="field.type"
+              :model-value="field.type || 'text'"
+              @update:model-value="field.type = $event as 'text' | 'select'"
               size="sm"
               :disabled="format.isReadonly"
               :options="typeOptions"

--- a/src/components/FormatEditor.vue
+++ b/src/components/FormatEditor.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
-import { ref, watch } from 'vue'
+import { ref, watch, computed } from 'vue'
+import { useI18n } from 'vue-i18n'
 import type { BranchFormatTemplate, Capitalization, FieldDefinition, LanguageProfile } from '@/core/FormatTypes'
 import CustomSelect from '@/components/CustomSelect.vue'
 
@@ -7,16 +8,35 @@ const props = defineProps<{
   format: BranchFormatTemplate
 }>()
 
-const emit = defineEmits(['save', 'cancel', 'update:format', 'toggle-visibility'])
+const emit = defineEmits(['save', 'cancel', 'update:format', 'toggle-visibility', 'update-language'])
+
+const { t } = useI18n()
 
 const localFormat = ref<BranchFormatTemplate>(JSON.parse(JSON.stringify(props.format)))
 
-const capitalizationOptions: { value: Capitalization; label: string }[] = [
-  { value: 'UPPERCASE', label: 'Mayúsculas' },
-  { value: 'LOWERCASE', label: 'Minúsculas' },
-  { value: 'AS_IS', label: 'Tal cual' }
-]
+// Los nombres/etiquetas de los formatos predefinidos son claves i18n (contienen un punto);
+// los de los formatos personalizados son texto libre y se muestran tal cual.
+const resolveLabel = (value: string) => value.includes('.') ? t(value) : value
 
+const displayName = computed(() => resolveLabel(localFormat.value.name))
+
+// En los formatos predefinidos solo se puede editar si están visibles/son el predeterminado
+// y el idioma (clave para el saneado multi-idioma); el resto queda bloqueado.
+const handleLanguageChange = (language: string) => {
+  const value = language as LanguageProfile
+  localFormat.value.language = value
+  if (props.format.isReadonly) {
+    emit('update-language', value)
+  }
+}
+
+const capitalizationOptions = computed<{ value: Capitalization; label: string }[]>(() => [
+  { value: 'UPPERCASE', label: t('configurator.editor.capUpper') },
+  { value: 'LOWERCASE', label: t('configurator.editor.capLower') },
+  { value: 'AS_IS', label: t('configurator.editor.capAsIs') }
+])
+
+// Los nombres de idioma se muestran siempre en su propio idioma nativo (no se traducen).
 const languageOptions: { value: LanguageProfile; label: string }[] = [
   { value: 'es', label: 'Español' },
   { value: 'en', label: 'English' },
@@ -25,6 +45,11 @@ const languageOptions: { value: LanguageProfile; label: string }[] = [
   { value: 'it', label: 'Italiano' },
   { value: 'pt', label: 'Português' }
 ]
+
+const typeOptions = computed(() => [
+  { value: 'text', label: t('configurator.editor.typeText') },
+  { value: 'select', label: t('configurator.editor.typeSelect') }
+])
 
 watch(() => props.format, (newFormat) => {
   localFormat.value = JSON.parse(JSON.stringify(newFormat))
@@ -38,7 +63,7 @@ const addField = () => {
   const newId = `campo${localFormat.value.fields.length + 1}`
   localFormat.value.fields.push({
     id: newId,
-    label: `Nuevo Campo`,
+    label: t('configurator.newFieldLabel'),
     capitalization: 'AS_IS',
     type: 'text'
   })
@@ -70,67 +95,80 @@ const updateOptions = (field: FieldDefinition, event: Event) => {
         @click="emit('toggle-visibility')"
       >
         <span class="switch-track"><span class="switch-thumb"></span></span>
-        <span class="switch-label">{{ format.isVisible ? 'Activado' : 'Desactivado' }}</span>
+        <span class="switch-label">{{ format.isVisible ? $t('configurator.editor.on') : $t('configurator.editor.off') }}</span>
       </button>
       <p class="switch-hint">
         {{ format.isVisible
-          ? 'Este formato aparece como opción en el formulario principal.'
-          : 'Este formato está oculto: no aparecerá como opción en el formulario principal.' }}
+          ? $t('configurator.editor.visibleHintOn')
+          : $t('configurator.editor.visibleHintOff') }}
       </p>
     </div>
 
     <p v-if="format.isReadonly" class="readonly-hint">
-      Este formato viene incluido en la app y no se puede modificar. Para personalizarlo, clónalo desde la lista y edita la copia.
+      {{ $t('configurator.editor.readonlyHint') }}
     </p>
 
     <div class="form-group">
-      <label class="form-label">Nombre del formato</label>
-      <input type="text" v-model="localFormat.name" class="input-element" :disabled="format.isReadonly" />
+      <label class="form-label">{{ $t('configurator.editor.formatName') }}</label>
+      <input
+        type="text"
+        :value="displayName"
+        @input="localFormat.name = ($event.target as HTMLInputElement).value"
+        class="input-element"
+        :disabled="format.isReadonly"
+      />
     </div>
 
     <div class="form-group">
-      <label class="form-label">Plantilla (Usa {id} para inyectar campos)</label>
+      <label class="form-label">{{ $t('configurator.editor.template') }}</label>
       <input type="text" v-model="localFormat.templateString" class="input-element" :disabled="format.isReadonly" />
     </div>
 
     <div class="form-group">
-      <label class="form-label">Idioma (saneado de caracteres: ñ, /, tildes...)</label>
-      <CustomSelect v-model="localFormat.language" :options="languageOptions" :disabled="format.isReadonly" />
+      <label class="form-label">{{ $t('configurator.editor.language') }}</label>
+      <CustomSelect :model-value="localFormat.language" :options="languageOptions" @update:modelValue="handleLanguageChange" />
     </div>
 
     <div class="fields-section">
-      <h4 class="form-label">Campos</h4>
+      <h4 class="form-label">{{ $t('configurator.editor.fields') }}</h4>
       <div v-for="(field, index) in localFormat.fields" :key="index" class="field-editor">
         <div class="field-editor-head">
-          <span class="field-index">Campo {{ index + 1 }}</span>
-          <button v-if="!format.isReadonly" @click="removeField(index)" class="icon-btn delete-btn" title="Eliminar campo">
+          <span class="field-index">{{ $t('configurator.editor.field', { n: index + 1 }) }}</span>
+          <button v-if="!format.isReadonly" @click="removeField(index)" class="icon-btn delete-btn" :title="$t('configurator.editor.deleteField')">
             <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M3 6h18"></path><path d="M19 6v14c0 1-1 2-2 2H7c-1 0-2-1-2-2V6"></path><path d="M8 6V4c0-1 1-2 2-2h4c1 0 2 1 2 2v2"></path></svg>
           </button>
         </div>
 
         <div class="field-header">
           <div class="field-control">
-            <label class="field-label-small">ID del Campo</label>
-            <input type="text" v-model="field.id" placeholder="ej: ticketId" class="input-element small" :disabled="format.isReadonly" />
+            <label class="field-label-small">{{ $t('configurator.editor.fieldId') }}</label>
+            <input type="text" v-model="field.id" :placeholder="$t('configurator.editor.fieldIdPlaceholder')" class="input-element small" :disabled="format.isReadonly" />
           </div>
 
           <div class="field-control">
-            <label class="field-label-small">Nombre del Campo</label>
-            <input type="text" v-model="field.label" placeholder="ej: ID Ticket" class="input-element small" :disabled="format.isReadonly" />
-          </div>
-
-          <div class="field-control type-select">
-            <label class="field-label-small">Tipo</label>
-            <CustomSelect
-              v-model="field.type"
-              size="sm"
+            <label class="field-label-small">{{ $t('configurator.editor.fieldLabel') }}</label>
+            <input
+              type="text"
+              :value="resolveLabel(field.label)"
+              @input="field.label = ($event.target as HTMLInputElement).value"
+              :placeholder="$t('configurator.editor.fieldLabelPlaceholder')"
+              class="input-element small"
               :disabled="format.isReadonly"
-              :options="[{value: 'text', label: 'Texto Libre'}, {value: 'select', label: 'Selector'}]"
             />
           </div>
 
           <div class="field-control type-select">
-            <label class="field-label-small">Capitalización</label>
+            <label class="field-label-small">{{ $t('configurator.editor.type') }}</label>
+            <CustomSelect
+              v-model="field.type"
+              size="sm"
+              :disabled="format.isReadonly"
+              :options="typeOptions"
+            />
+          </div>
+
+          <div class="field-control type-select">
+            <label class="field-label-small">{{ $t('configurator.editor.capitalization') }}</label>
             <CustomSelect
               v-model="field.capitalization"
               size="sm"
@@ -141,25 +179,25 @@ const updateOptions = (field: FieldDefinition, event: Event) => {
         </div>
 
         <div v-if="field.type === 'select'" class="field-options-control">
-          <label class="field-label-small">Opciones (separadas por comas)</label>
+          <label class="field-label-small">{{ $t('configurator.editor.options') }}</label>
           <input
             type="text"
             :value="(field.options || []).join(', ')"
             @input="updateOptions(field, $event)"
-            placeholder="ej: feature, fix, hotfix"
+            :placeholder="$t('configurator.editor.optionsPlaceholder')"
             class="input-element small"
             :disabled="format.isReadonly"
           />
         </div>
       </div>
-      <button v-if="!format.isReadonly" @click="addField" class="btn-secondary">+ Añadir Campo</button>
+      <button v-if="!format.isReadonly" @click="addField" class="btn-secondary">{{ $t('configurator.editor.addField') }}</button>
     </div>
 
     <div class="actions">
-      <button v-if="format.isReadonly" @click="emit('cancel')" class="btn-secondary">Cerrar</button>
+      <button v-if="format.isReadonly" @click="emit('cancel')" class="btn-secondary">{{ $t('configurator.editor.close') }}</button>
       <template v-else>
-        <button @click="emit('cancel')" class="btn-secondary">Cancelar</button>
-        <button @click="handleSave" class="btn-primary">Guardar</button>
+        <button @click="emit('cancel')" class="btn-secondary">{{ $t('configurator.editor.cancel') }}</button>
+        <button @click="handleSave" class="btn-primary">{{ $t('configurator.editor.save') }}</button>
       </template>
     </div>
   </div>

--- a/src/components/FormatPreview.vue
+++ b/src/components/FormatPreview.vue
@@ -1,0 +1,50 @@
+<script setup lang="ts">
+import { computed } from 'vue'
+import type { BranchFormatTemplate } from '@/core/FormatTypes'
+import { BranchFormatter } from '@/core/BranchFormatter'
+
+const props = defineProps<{
+  format: BranchFormatTemplate | null
+}>()
+
+const previewName = computed(() => {
+  if (!props.format) return 'Selecciona un formato'
+  
+  const fakeData: Record<string, string> = {}
+  props.format.fields.forEach(f => {
+    fakeData[f.id] = `ejemplo-${f.id}`
+  })
+  
+  return BranchFormatter.format(props.format, fakeData)
+})
+</script>
+
+<template>
+  <div class="preview-box">
+    <h3 class="preview-title">Previsualización</h3>
+    <code class="preview-code">{{ previewName }}</code>
+  </div>
+</template>
+
+<style scoped lang="scss">
+.preview-box {
+  background-color: var(--bg-surface);
+  border: 1px solid var(--border-color);
+  border-radius: 8px;
+  padding: 1rem;
+  margin-bottom: 1.5rem;
+  text-align: center;
+}
+.preview-title {
+  font-size: 0.85rem;
+  color: var(--text-muted);
+  text-transform: uppercase;
+  margin-bottom: 0.5rem;
+}
+.preview-code {
+  font-size: 1.25rem;
+  font-weight: 600;
+  color: var(--text-main);
+  word-break: break-all;
+}
+</style>

--- a/src/components/FormatPreview.vue
+++ b/src/components/FormatPreview.vue
@@ -12,7 +12,7 @@ const previewName = computed(() => {
   
   const fakeData: Record<string, string> = {}
   props.format.fields.forEach(f => {
-    fakeData[f.id] = `ejemplo-${f.id}`
+    fakeData[f.id] = f.id
   })
   
   return BranchFormatter.format(props.format, fakeData)
@@ -42,9 +42,10 @@ const previewName = computed(() => {
   margin-bottom: 0.5rem;
 }
 .preview-code {
-  font-size: 1.25rem;
+  font-size: clamp(1rem, 0.85rem + 1vw, 1.25rem);
   font-weight: 600;
   color: var(--text-main);
-  word-break: break-all;
+  overflow-wrap: break-word;
+  display: inline-block;
 }
 </style>

--- a/src/components/FormatPreview.vue
+++ b/src/components/FormatPreview.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import { computed } from 'vue'
+import { useI18n } from 'vue-i18n'
 import type { BranchFormatTemplate } from '@/core/FormatTypes'
 import { BranchFormatter } from '@/core/BranchFormatter'
 
@@ -7,21 +8,23 @@ const props = defineProps<{
   format: BranchFormatTemplate | null
 }>()
 
+const { t } = useI18n()
+
 const previewName = computed(() => {
-  if (!props.format) return 'Selecciona un formato'
-  
+  if (!props.format) return t('preview.placeholder')
+
   const fakeData: Record<string, string> = {}
   props.format.fields.forEach(f => {
     fakeData[f.id] = f.id
   })
-  
+
   return BranchFormatter.format(props.format, fakeData)
 })
 </script>
 
 <template>
   <div class="preview-box">
-    <h3 class="preview-title">Previsualización</h3>
+    <h3 class="preview-title">{{ $t('preview.title') }}</h3>
     <code class="preview-code">{{ previewName }}</code>
   </div>
 </template>

--- a/src/components/SettingsIcon.vue
+++ b/src/components/SettingsIcon.vue
@@ -1,0 +1,31 @@
+<!-- src/components/SettingsIcon.vue -->
+<script setup lang="ts"></script>
+
+<template>
+  <svg
+    class="settings-icon"
+    viewBox="0 0 24 24"
+    xmlns="http://www.w3.org/2000/svg"
+    fill="none"
+    stroke="currentColor"
+    stroke-width="2"
+    stroke-linecap="round"
+    stroke-linejoin="round"
+    aria-hidden="true"
+    focusable="false"
+  >
+    <circle cx="12" cy="12" r="3" />
+    <path
+      d="M19.4 15a1.65 1.65 0 0 0 .33 1.82l.06.06a2 2 0 1 1-2.83 2.83l-.06-.06a1.65 1.65 0 0 0-1.82-.33 1.65 1.65 0 0 0-1 1.51V21a2 2 0 0 1-4 0v-.09A1.65 1.65 0 0 0 9 19.4a1.65 1.65 0 0 0-1.82.33l-.06.06a2 2 0 1 1-2.83-2.83l.06-.06a1.65 1.65 0 0 0 .33-1.82 1.65 1.65 0 0 0-1.51-1H3a2 2 0 0 1 0-4h.09A1.65 1.65 0 0 0 4.6 9a1.65 1.65 0 0 0-.33-1.82l-.06-.06a2 2 0 1 1 2.83-2.83l.06.06a1.65 1.65 0 0 0 1.82.33H9a1.65 1.65 0 0 0 1-1.51V3a2 2 0 0 1 4 0v.09a1.65 1.65 0 0 0 1 1.51 1.65 1.65 0 0 0 1.82-.33l.06-.06a2 2 0 1 1 2.83 2.83l-.06.06a1.65 1.65 0 0 0-.33 1.82V9a1.65 1.65 0 0 0 1.51 1H21a2 2 0 0 1 0 4h-.09a1.65 1.65 0 0 0-1.51 1z"
+    />
+  </svg>
+</template>
+
+<style scoped lang="scss">
+.settings-icon {
+  width: 1.1rem;
+  height: 1.1rem;
+  flex-shrink: 0;
+  display: inline-block;
+}
+</style>

--- a/src/components/__tests__/BranchForm.spec.ts
+++ b/src/components/__tests__/BranchForm.spec.ts
@@ -2,6 +2,7 @@ import { mount } from '@vue/test-utils'
 import { describe, expect, it } from 'vitest'
 import BranchForm from '../BranchForm.vue'
 import { FormatManager } from '@/core/FormatManager'
+import i18n from '@/i18n'
 
 // Mocking FormatManager for the tests
 FormatManager.getVisibleFormats = () => [
@@ -22,9 +23,7 @@ describe('BranchForm', () => {
   it('renders the dynamic form correctly', () => {
     const wrapper = mount(BranchForm, {
       global: {
-        mocks: {
-          $t: (msg: string) => msg
-        }
+        plugins: [i18n]
       }
     })
     // Expect input with name testId to exist
@@ -34,9 +33,7 @@ describe('BranchForm', () => {
   it('emits submitForm event with correct payload', async () => {
     const wrapper = mount(BranchForm, {
       global: {
-        mocks: {
-          $t: (msg: string) => msg
-        }
+        plugins: [i18n]
       }
     })
 

--- a/src/components/__tests__/BranchForm.spec.ts
+++ b/src/components/__tests__/BranchForm.spec.ts
@@ -4,6 +4,8 @@ import BranchForm from '../BranchForm.vue'
 import { FormatManager } from '@/core/FormatManager'
 import i18n from '@/i18n'
 
+import { nextTick } from 'vue'
+
 // Mocking FormatManager for the tests
 FormatManager.getVisibleFormats = () => [
   {
@@ -12,20 +14,21 @@ FormatManager.getVisibleFormats = () => [
     templateString: '{testId}',
     isReadonly: false,
     isVisible: true,
-    language: 'es',
     fields: [
-      { id: 'testId', label: 'Test ID', capitalization: 'AS_IS' }
+      { id: 'testId', label: 'Test ID', type: 'text', operations: [] }
     ]
   }
 ]
+FormatManager.getDefaultFormatId = () => 'test'
 
 describe('BranchForm', () => {
-  it('renders the dynamic form correctly', () => {
+  it('renders the dynamic form correctly', async () => {
     const wrapper = mount(BranchForm, {
       global: {
         plugins: [i18n]
       }
     })
+    await nextTick()
     // Expect input with name testId to exist
     expect(wrapper.find('input[name="testId"]').exists()).toBe(true)
   })
@@ -36,6 +39,7 @@ describe('BranchForm', () => {
         plugins: [i18n]
       }
     })
+    await nextTick()
 
     const input = wrapper.find('input[name="testId"]')
     await input.setValue('my-test-value')

--- a/src/components/__tests__/BranchForm.spec.ts
+++ b/src/components/__tests__/BranchForm.spec.ts
@@ -11,8 +11,9 @@ FormatManager.getVisibleFormats = () => [
     templateString: '{testId}',
     isReadonly: false,
     isVisible: true,
+    language: 'es',
     fields: [
-      { id: 'testId', label: 'Test ID', operations: [] }
+      { id: 'testId', label: 'Test ID', capitalization: 'AS_IS' }
     ]
   }
 ]

--- a/src/components/__tests__/BranchForm.spec.ts
+++ b/src/components/__tests__/BranchForm.spec.ts
@@ -1,10 +1,24 @@
-import { describe, it, expect } from 'vitest'
 import { mount } from '@vue/test-utils'
+import { describe, expect, it } from 'vitest'
 import BranchForm from '../BranchForm.vue'
-import type { BranchFormType } from '@/core/BranchTypes'
+import { FormatManager } from '@/core/FormatManager'
+
+// Mocking FormatManager for the tests
+FormatManager.getVisibleFormats = () => [
+  {
+    id: 'test',
+    name: 'Test',
+    templateString: '{testId}',
+    isReadonly: false,
+    isVisible: true,
+    fields: [
+      { id: 'testId', label: 'Test ID', operations: [] }
+    ]
+  }
+]
 
 describe('BranchForm', () => {
-  it('renders the form correctly', () => {
+  it('renders the dynamic form correctly', () => {
     const wrapper = mount(BranchForm, {
       global: {
         mocks: {
@@ -12,14 +26,11 @@ describe('BranchForm', () => {
         }
       }
     })
-    expect(wrapper.find('form[aria-label="Create branch name form"]').exists()).toBe(true)
-    expect(wrapper.find('input[name="ticket-id"]').exists()).toBe(true)
-    expect(wrapper.find('input[name="develop-name"]').exists()).toBe(true)
-    expect(wrapper.find('input[name="project-id"]').exists()).toBe(true)
-    expect(wrapper.find('button[type="submit"]').exists()).toBe(true)
+    // Expect input with name testId to exist
+    expect(wrapper.find('input[name="testId"]').exists()).toBe(true)
   })
 
-  it('emits submitForm event with correct payload when form is submitted', async () => {
+  it('emits submitForm event with correct payload', async () => {
     const wrapper = mount(BranchForm, {
       global: {
         mocks: {
@@ -27,26 +38,13 @@ describe('BranchForm', () => {
         }
       }
     })
-    const ticketIdInput = wrapper.find('input[name="ticket-id"]')
-    const featureNameInput = wrapper.find('input[name="develop-name"]')
-    const projectIdInput = wrapper.find('input[name="project-id"]')
 
-    await projectIdInput.setValue('PROJ')
+    const input = wrapper.find('input[name="testId"]')
+    await input.setValue('my-test-value')
+    await wrapper.find('form').trigger('submit')
 
-    await ticketIdInput.setValue('12345')
-    await featureNameInput.setValue('feature-branch')
-
-    await wrapper.find('form').trigger('submit.prevent')
-
-    const emittedEvents = wrapper.emitted()
-    console.log('Emitted Events:', emittedEvents)
-    const submitFormEvent = emittedEvents.submitForm as Array<Array<BranchFormType>>
-    expect(submitFormEvent).toBeTruthy()
-    const emittedPayload = submitFormEvent![0][0] as BranchFormType
-    expect(emittedPayload).toMatchObject({
-      projectId: 'PROJ',
-      ticketId: '12345',
-      featureName: 'feature-branch'
-    })
+    const emitted = wrapper.emitted('submitForm')
+    expect(emitted).toBeTruthy()
+    expect(emitted![0][1]).toEqual({ testId: 'my-test-value' })
   })
 })

--- a/src/components/__tests__/BranchForm.spec.ts
+++ b/src/components/__tests__/BranchForm.spec.ts
@@ -14,8 +14,9 @@ FormatManager.getVisibleFormats = () => [
     templateString: '{testId}',
     isReadonly: false,
     isVisible: true,
+    language: 'es',
     fields: [
-      { id: 'testId', label: 'Test ID', type: 'text', operations: [] }
+      { id: 'testId', label: 'Test ID', type: 'text', capitalization: 'AS_IS' }
     ]
   }
 ]

--- a/src/components/__tests__/BranchItem.spec.ts
+++ b/src/components/__tests__/BranchItem.spec.ts
@@ -9,24 +9,15 @@ describe('BranchList.vue', () => {
     const branches: Branch[] = [
       new Branch({
         id: 1,
-        ticketId: 'T1',
-        featureName: 'Feature1',
-        branchName: 'T1-Feature1',
-        projectId: 'PROJ1'
+        branchName: 'T1-Feature1'
       }),
       new Branch({
         id: 2,
-        ticketId: 'T2',
-        featureName: 'Feature2',
-        branchName: 'T2-Feature2',
-        projectId: 'PROJ2'
+        branchName: 'T2-Feature2'
       }),
       new Branch({
         id: 3,
-        ticketId: 'T3',
-        featureName: 'Feature3',
-        branchName: 'T3-Feature3',
-        projectId: 'PROJ3'
+        branchName: 'T3-Feature3'
       })
     ]
 
@@ -47,17 +38,11 @@ describe('BranchList.vue', () => {
     const branches: Branch[] = [
       new Branch({
         id: 1,
-        ticketId: 'T1',
-        featureName: 'Feature1',
-        branchName: 'T1-Feature1',
-        projectId: 'PROJ1'
+        branchName: 'T1-Feature1'
       }),
       new Branch({
         id: 2,
-        ticketId: 'T2',
-        featureName: 'Feature2',
-        branchName: 'T2-Feature2',
-        projectId: 'PROJ2'
+        branchName: 'T2-Feature2'
       })
     ]
 
@@ -72,24 +57,15 @@ describe('BranchList.vue', () => {
     const newBranches: Branch[] = [
       new Branch({
         id: 1,
-        ticketId: 'T1',
-        featureName: 'Feature1',
-        branchName: 'T1-Feature1',
-        projectId: 'PROJ1'
+        branchName: 'T1-Feature1'
       }),
       new Branch({
         id: 2,
-        ticketId: 'T2',
-        featureName: 'Feature2',
-        branchName: 'T2-Feature2',
-        projectId: 'PROJ2'
+        branchName: 'T2-Feature2'
       }),
       new Branch({
         id: 3,
-        ticketId: 'T3',
-        featureName: 'Feature3',
-        branchName: 'T3-Feature3',
-        projectId: 'PROJ3'
+        branchName: 'T3-Feature3'
       })
     ]
 
@@ -107,10 +83,7 @@ describe('BranchList.vue', () => {
     const branches: Branch[] = [
       new Branch({
         id: 1,
-        ticketId: 'T1',
-        featureName: 'Feature1',
-        branchName: 'T1-Feature1',
-        projectId: 'PROJ1'
+        branchName: 'T1-Feature1'
       })
     ]
 
@@ -130,10 +103,7 @@ describe('BranchItem.vue', () => {
   it('renders branch item correctly', () => {
     const branch = new Branch({
       id: 1,
-      ticketId: 'T1',
-      featureName: 'Feature1',
-      branchName: 'T1-Feature1',
-      projectId: 'PROJ'
+      branchName: 'T1-Feature1'
     })
 
     const wrapper = mount(BranchItem, {

--- a/src/components/__tests__/BranchItem.spec.ts
+++ b/src/components/__tests__/BranchItem.spec.ts
@@ -31,7 +31,8 @@ describe('BranchList.vue', () => {
     ]
 
     const wrapper = mount(BranchList, {
-      props: { branches }
+      props: { branches },
+      global: { mocks: { $t: (msg: string) => msg } }
     })
 
     const items = wrapper.findAllComponents(BranchItem)
@@ -61,7 +62,8 @@ describe('BranchList.vue', () => {
     ]
 
     const wrapper = mount(BranchList, {
-      props: { branches }
+      props: { branches },
+      global: { mocks: { $t: (msg: string) => msg } }
     })
 
     let items = wrapper.findAllComponents(BranchItem)
@@ -113,7 +115,8 @@ describe('BranchList.vue', () => {
     ]
 
     const wrapper = mount(BranchList, {
-      props: { branches }
+      props: { branches },
+      global: { mocks: { $t: (msg: string) => msg } }
     })
 
     await wrapper.findComponent(BranchItem).vm.$emit('deleteBranch', 1)
@@ -137,7 +140,8 @@ describe('BranchItem.vue', () => {
       props: {
         branchName: branch.branchName,
         branchId: branch.id
-      }
+      },
+      global: { mocks: { $t: (msg: string) => msg } }
     })
 
     expect(wrapper.text()).toContain(branch.branchName)

--- a/src/components/__tests__/BranchList.spec.ts
+++ b/src/components/__tests__/BranchList.spec.ts
@@ -31,7 +31,8 @@ describe('BranchList.vue', () => {
     ]
 
     const wrapper = mount(BranchList, {
-      props: { branches }
+      props: { branches },
+      global: { mocks: { $t: (msg: string) => msg } }
     })
 
     const items = wrapper.findAllComponents(BranchItem)
@@ -61,7 +62,8 @@ describe('BranchList.vue', () => {
     ]
 
     const wrapper = mount(BranchList, {
-      props: { branches }
+      props: { branches },
+      global: { mocks: { $t: (msg: string) => msg } }
     })
 
     let items = wrapper.findAllComponents(BranchItem)

--- a/src/components/__tests__/BranchList.spec.ts
+++ b/src/components/__tests__/BranchList.spec.ts
@@ -9,24 +9,15 @@ describe('BranchList.vue', () => {
     const branches: Branch[] = [
       new Branch({
         id: 1,
-        ticketId: 'T1',
-        featureName: 'Feature1',
-        branchName: 'T1-Feature1',
-        projectId: 'PROJ1'
+        branchName: 'T1-Feature1'
       }),
       new Branch({
         id: 2,
-        ticketId: 'T2',
-        featureName: 'Feature2',
-        branchName: 'T2-Feature2',
-        projectId: 'PROJ2'
+        branchName: 'T2-Feature2'
       }),
       new Branch({
         id: 3,
-        ticketId: 'T3',
-        featureName: 'Feature3',
-        branchName: 'T3-Feature3',
-        projectId: 'PROJ3'
+        branchName: 'T3-Feature3'
       })
     ]
 
@@ -47,17 +38,11 @@ describe('BranchList.vue', () => {
     const branches: Branch[] = [
       new Branch({
         id: 1,
-        ticketId: 'T1',
-        featureName: 'Feature1',
-        branchName: 'T1-Feature1',
-        projectId: 'PROJ1'
+        branchName: 'T1-Feature1'
       }),
       new Branch({
         id: 2,
-        ticketId: 'T2',
-        featureName: 'Feature2',
-        branchName: 'T2-Feature2',
-        projectId: 'PROJ2'
+        branchName: 'T2-Feature2'
       })
     ]
 
@@ -72,24 +57,15 @@ describe('BranchList.vue', () => {
     const newBranches: Branch[] = [
       new Branch({
         id: 1,
-        ticketId: 'T1',
-        featureName: 'Feature1',
-        branchName: 'T1-Feature1',
-        projectId: 'PROJ1'
+        branchName: 'T1-Feature1'
       }),
       new Branch({
         id: 2,
-        ticketId: 'T2',
-        featureName: 'Feature2',
-        branchName: 'T2-Feature2',
-        projectId: 'PROJ2'
+        branchName: 'T2-Feature2'
       }),
       new Branch({
         id: 3,
-        ticketId: 'T3',
-        featureName: 'Feature3',
-        branchName: 'T3-Feature3',
-        projectId: 'PROJ3'
+        branchName: 'T3-Feature3'
       })
     ]
 

--- a/src/components/__tests__/CustomModal.spec.ts
+++ b/src/components/__tests__/CustomModal.spec.ts
@@ -1,0 +1,74 @@
+import { mount } from '@vue/test-utils'
+import { describe, expect, it } from 'vitest'
+import CustomModal from '../CustomModal.vue'
+import i18n from '@/i18n'
+
+describe('CustomModal', () => {
+  it('renders nothing when modelValue is false', () => {
+    const wrapper = mount(CustomModal, {
+      global: { plugins: [i18n] },
+      props: {
+        modelValue: false,
+        title: 'Test',
+        message: 'Message'
+      }
+    })
+    expect(wrapper.find('.modal-overlay').exists()).toBe(false)
+  })
+
+  it('renders modal content when modelValue is true', () => {
+    const wrapper = mount(CustomModal, {
+      global: { plugins: [i18n] },
+      props: {
+        modelValue: true,
+        title: 'Test Title',
+        message: 'Test Message'
+      }
+    })
+    expect(wrapper.find('.modal-overlay').exists()).toBe(true)
+    expect(wrapper.text()).toContain('Test Title')
+    expect(wrapper.text()).toContain('Test Message')
+  })
+
+  it('emits confirm event when confirm button is clicked', async () => {
+    const wrapper = mount(CustomModal, {
+      global: { plugins: [i18n] },
+      props: {
+        modelValue: true,
+        title: 'Test',
+        message: 'Message'
+      }
+    })
+    await wrapper.find('.btn-primary').trigger('click')
+    expect(wrapper.emitted('confirm')).toBeTruthy()
+    expect(wrapper.emitted('update:modelValue')![0]).toEqual([false])
+  })
+
+  it('emits cancel event when cancel button is clicked', async () => {
+    const wrapper = mount(CustomModal, {
+      global: { plugins: [i18n] },
+      props: {
+        modelValue: true,
+        title: 'Test',
+        message: 'Message'
+      }
+    })
+    await wrapper.find('.btn-secondary').trigger('click')
+    expect(wrapper.emitted('cancel')).toBeTruthy()
+    expect(wrapper.emitted('update:modelValue')![0]).toEqual([false])
+  })
+
+  it('applies danger class to confirm button if danger prop is true', () => {
+    const wrapper = mount(CustomModal, {
+      global: { plugins: [i18n] },
+      props: {
+        modelValue: true,
+        title: 'Test',
+        message: 'Message',
+        danger: true
+      }
+    })
+    expect(wrapper.find('.btn-danger').exists()).toBe(true)
+    expect(wrapper.find('.btn-primary').exists()).toBe(false)
+  })
+})

--- a/src/components/__tests__/CustomSelect.spec.ts
+++ b/src/components/__tests__/CustomSelect.spec.ts
@@ -1,0 +1,95 @@
+import { mount } from '@vue/test-utils'
+import { describe, expect, it, vi } from 'vitest'
+import CustomSelect from '../CustomSelect.vue'
+import { nextTick } from 'vue'
+
+describe('CustomSelect', () => {
+  const options = [
+    { value: 'opt1', label: 'Option 1' },
+    { value: 'opt2', label: 'Option 2' },
+    { value: 'opt3', label: 'Option 3' }
+  ]
+
+  it('renders correctly with initial value', () => {
+    const wrapper = mount(CustomSelect, {
+      props: {
+        modelValue: 'opt2',
+        options
+      }
+    })
+    expect(wrapper.find('.select-label').text()).toBe('Option 2')
+    expect(wrapper.find('input[type="hidden"]').attributes('value')).toBe('opt2')
+  })
+
+  it('shows placeholder when no value is provided', () => {
+    const wrapper = mount(CustomSelect, {
+      props: {
+        modelValue: '',
+        options,
+        placeholder: 'Select one'
+      }
+    })
+    expect(wrapper.find('.select-label').text()).toBe('Select one')
+    expect(wrapper.find('.select-label').classes()).toContain('placeholder')
+  })
+
+  it('toggles dropdown on click', async () => {
+    const wrapper = mount(CustomSelect, {
+      props: { modelValue: '', options }
+    })
+    const trigger = wrapper.find('.custom-select-trigger')
+    
+    // initially closed
+    expect(wrapper.find('.custom-select-dropdown').exists()).toBe(false)
+    
+    // click to open
+    await trigger.trigger('click')
+    expect(wrapper.find('.custom-select-dropdown').exists()).toBe(true)
+
+    // click to close
+    await trigger.trigger('click')
+    // Vue transition might keep it in DOM for a moment, but isOpen becomes false
+    // Since we mock or don't use real CSS transitions in simple tests, it might disappear immediately
+    expect(wrapper.find('.custom-select-dropdown').exists()).toBe(false)
+  })
+
+  it('emits update:modelValue on option click', async () => {
+    const wrapper = mount(CustomSelect, {
+      props: { modelValue: '', options }
+    })
+    
+    await wrapper.find('.custom-select-trigger').trigger('click')
+    
+    const optionButtons = wrapper.findAll('.select-option')
+    expect(optionButtons).toHaveLength(3)
+    
+    await optionButtons[1].trigger('click')
+    
+    expect(wrapper.emitted('update:modelValue')).toBeTruthy()
+    expect(wrapper.emitted('update:modelValue')![0]).toEqual(['opt2'])
+  })
+
+  it('supports keyboard navigation', async () => {
+    const wrapper = mount(CustomSelect, {
+      props: { modelValue: 'opt1', options }
+    })
+    
+    const trigger = wrapper.find('.custom-select-trigger')
+    
+    // Open with ArrowDown
+    await trigger.trigger('keydown', { key: 'ArrowDown' })
+    expect(wrapper.find('.custom-select-dropdown').exists()).toBe(true)
+    
+    await nextTick() // wait for DOM to update and refs to be set
+
+    // We can test that events are fired on the options, but actual focus management 
+    // in JSDOM is limited. We'll at least simulate emitting keydowns.
+    const firstOption = wrapper.findAll('.select-option')[0]
+    await firstOption.trigger('keydown', { key: 'ArrowDown' })
+    // It should focus next item, but since focus testing is hard in jest/vitest without attached DOM,
+    // we just ensure it doesn't crash and handlers are reachable.
+
+    await firstOption.trigger('keydown', { key: 'Escape' })
+    expect(wrapper.find('.custom-select-dropdown').exists()).toBe(false)
+  })
+})

--- a/src/core/Branch.ts
+++ b/src/core/Branch.ts
@@ -1,18 +1,13 @@
 import type { BranchType } from '@/core/BranchTypes'
-import { BranchFormatter } from '@/core/BranchFormatter'
 
 export class Branch implements BranchType {
   id: number
-  projectId: string
-  ticketId: string
-  featureName: string
   branchName: string
+  formatId?: string
 
   constructor(branch: BranchType) {
     this.id = branch.id
-    this.projectId = branch.projectId
-    this.ticketId = branch.ticketId
-    this.featureName = branch.featureName
-    this.branchName = BranchFormatter.format(branch)
+    this.branchName = branch.branchName
+    this.formatId = branch.formatId
   }
 }

--- a/src/core/BranchFormatter.ts
+++ b/src/core/BranchFormatter.ts
@@ -1,72 +1,68 @@
-import type { BranchType } from '@/core/BranchTypes'
+import type { BranchFormatTemplate, FormatOperation } from '@/core/FormatTypes'
+import type { BranchFormType } from '@/core/BranchTypes'
 
 export class BranchFormatter {
-  static format(branch: BranchType): string {
-    const projectId: string = branch.projectId ? this.cleanProjectId(branch.projectId) : ''
-    const ticketId: string = branch.ticketId ? this.cleanTicketId(branch.ticketId) : ''
-    const featureName: string = branch.featureName ? this.cleanFeatureName(branch.featureName) : ''
-    return this.removeLeadingAndTrailingDashes(`${projectId}-${ticketId}--${featureName}`)
+  static format(template: BranchFormatTemplate, values: BranchFormType): string {
+    let result = template.templateString
+
+    for (const field of template.fields) {
+      const rawValue = values[field.id] || ''
+      const formattedValue = this.applyOperations(rawValue, field.operations)
+
+      const placeholder = `{${field.id}}`
+      result = result.split(placeholder).join(formattedValue)
+    }
+
+    return this.removeLeadingAndTrailingDashes(result)
+  }
+
+  static applyOperations(text: string, operations: FormatOperation[]): string {
+    let result = text
+    for (const op of operations) {
+      switch (op) {
+        case 'UPPERCASE':
+          result = result.toUpperCase()
+          break
+        case 'LOWERCASE':
+          result = result.toLowerCase()
+          break
+        case 'REPLACE_SLASHES':
+          result = result.replace(/\//g, '-o-')
+          break
+        case 'REPLACE_DOTS':
+          result = result.replace(/\./g, '-')
+          break
+        case 'REPLACE_SPACES':
+          result = result.replace(/\s/g, '-')
+          break
+        case 'REMOVE_MULTIPLE_DASHES':
+          result = result.replace(/-+/g, '-')
+          break
+        case 'SET_NY':
+          result = result.replace(/ñ/g, 'ny').replace(/Ñ/g, 'NY')
+          break
+        case 'REMOVE_ACCENTS':
+          result = result.normalize('NFD').replace(/[\u0300-\u036f]/g, '')
+          break
+        case 'REMOVE_SPECIAL_CHARS':
+          result = result.replace(/[^a-zA-Z0-9-]/g, '')
+          break
+        case 'BASIC_CLEAN':
+          result = this.applyOperations(result, [
+            'REPLACE_DOTS',
+            'REPLACE_SPACES',
+            'REMOVE_MULTIPLE_DASHES',
+            'SET_NY',
+            'REMOVE_ACCENTS',
+            'REMOVE_SPECIAL_CHARS'
+          ])
+          break
+      }
+    }
+    return result
   }
 
   private static removeLeadingAndTrailingDashes(text: string): string {
     return text.replace(/^-+|-+$/g, '')
-  }
-
-  private static cleanProjectId(projectId: string): string {
-    return this.basicClean(this.toUpperCase(projectId))
-  }
-
-  private static cleanTicketId(ticketId: string): string {
-    return this.basicClean(this.toUpperCase(ticketId))
-  }
-
-  private static toUpperCase(text: string): string {
-    return text.toUpperCase()
-  }
-
-  private static cleanFeatureName(featureName: string): string {
-    return this.basicClean(this.replaceSlash(this.toLowerCase(featureName)))
-  }
-
-  private static toLowerCase(text: string): string {
-    return text.toLowerCase()
-  }
-
-  private static replaceSlash(text: string): string {
-    return text.replace(/\//g, '-o-')
-  }
-
-  private static basicClean(text: string): string {
-    text = this.replaceDots(text)
-    text = this.replaceSpaces(text)
-    text = this.removeMultipleDashes(text)
-    text = this.removeSpecialCharacters(text)
-    return text
-  }
-
-  private static replaceDots(text: string): string {
-    return text.replace(/\./g, '-')
-  }
-
-  private static replaceSpaces(text: string): string {
-    return text.replace(/\s/g, '-')
-  }
-
-  private static removeMultipleDashes(text: string): string {
-    return text.replace(/-+/g, '-')
-  }
-
-  private static removeSpecialCharacters(text: string): string {
-    text = this.setNy(text)
-    text = this.removeAccents(text)
-    return text.replace(/[^a-zA-Z0-9-]/g, '')
-  }
-
-  private static setNy(text: string): string {
-    return text.replace(/ñ/g, 'ny')
-  }
-
-  private static removeAccents(text: string): string {
-    return text.normalize('NFD').replace(/[\u0300-\u036f]/g, '')
   }
 }

--- a/src/core/BranchFormatter.ts
+++ b/src/core/BranchFormatter.ts
@@ -1,5 +1,19 @@
-import type { BranchFormatTemplate, FormatOperation } from '@/core/FormatTypes'
+import type { BranchFormatTemplate, Capitalization, LanguageProfile } from '@/core/FormatTypes'
 import type { BranchFormType } from '@/core/BranchTypes'
+
+interface LanguageRules {
+  slashWord: string; // "/" se sustituye por "-{slashWord}-"
+  charMap?: [RegExp, string][]; // sustituciones específicas del idioma que deben aplicarse antes de quitar tildes
+}
+
+const LANGUAGE_RULES: Record<LanguageProfile, LanguageRules> = {
+  es: { slashWord: 'o', charMap: [[/ñ/g, 'ny'], [/Ñ/g, 'NY']] },
+  en: { slashWord: 'or' },
+  fr: { slashWord: 'ou' },
+  de: { slashWord: 'oder', charMap: [[/ß/g, 'ss']] },
+  it: { slashWord: 'o' },
+  pt: { slashWord: 'ou' }
+}
 
 export class BranchFormatter {
   static format(template: BranchFormatTemplate, values: BranchFormType): string {
@@ -7,7 +21,8 @@ export class BranchFormatter {
 
     for (const field of template.fields) {
       const rawValue = values[field.id] || ''
-      const formattedValue = this.applyOperations(rawValue, field.operations)
+      const sanitized = this.sanitize(rawValue, template.language)
+      const formattedValue = this.applyCapitalization(sanitized, field.capitalization)
 
       const placeholder = `{${field.id}}`
       result = result.split(placeholder).join(formattedValue)
@@ -16,50 +31,33 @@ export class BranchFormatter {
     return this.removeLeadingAndTrailingDashes(result)
   }
 
-  static applyOperations(text: string, operations: FormatOperation[]): string {
+  // Saneado fijo: garantiza un nombre de rama válido en git, independientemente de la configuración del campo.
+  private static sanitize(text: string, language: LanguageProfile): string {
+    const rules = LANGUAGE_RULES[language]
     let result = text
-    for (const op of operations) {
-      switch (op) {
-        case 'UPPERCASE':
-          result = result.toUpperCase()
-          break
-        case 'LOWERCASE':
-          result = result.toLowerCase()
-          break
-        case 'REPLACE_SLASHES':
-          result = result.replace(/\//g, '-o-')
-          break
-        case 'REPLACE_DOTS':
-          result = result.replace(/\./g, '-')
-          break
-        case 'REPLACE_SPACES':
-          result = result.replace(/\s/g, '-')
-          break
-        case 'REMOVE_MULTIPLE_DASHES':
-          result = result.replace(/-+/g, '-')
-          break
-        case 'SET_NY':
-          result = result.replace(/ñ/g, 'ny').replace(/Ñ/g, 'NY')
-          break
-        case 'REMOVE_ACCENTS':
-          result = result.normalize('NFD').replace(/[\u0300-\u036f]/g, '')
-          break
-        case 'REMOVE_SPECIAL_CHARS':
-          result = result.replace(/[^a-zA-Z0-9-]/g, '')
-          break
-        case 'BASIC_CLEAN':
-          result = this.applyOperations(result, [
-            'REPLACE_DOTS',
-            'REPLACE_SPACES',
-            'REMOVE_MULTIPLE_DASHES',
-            'SET_NY',
-            'REMOVE_ACCENTS',
-            'REMOVE_SPECIAL_CHARS'
-          ])
-          break
-      }
+
+    result = result.replace(/\//g, `-${rules.slashWord}-`)
+    for (const [pattern, replacement] of rules.charMap ?? []) {
+      result = result.replace(pattern, replacement)
     }
+    result = result.replace(/\./g, '-')
+    result = result.replace(/\s/g, '-')
+    result = result.normalize('NFD').replace(/[\u0300-\u036f]/g, '')
+    result = result.replace(/[^a-zA-Z0-9-]/g, '')
+    result = result.replace(/-+/g, '-')
+
     return result
+  }
+
+  private static applyCapitalization(text: string, capitalization: Capitalization): string {
+    switch (capitalization) {
+      case 'UPPERCASE':
+        return text.toUpperCase()
+      case 'LOWERCASE':
+        return text.toLowerCase()
+      default:
+        return text
+    }
   }
 
   private static removeLeadingAndTrailingDashes(text: string): string {

--- a/src/core/BranchManager.ts
+++ b/src/core/BranchManager.ts
@@ -1,5 +1,5 @@
 import { Branch } from '@/core/Branch'
-import type { BranchFormType } from '@/core/BranchTypes'
+import type { BranchType } from '@/core/BranchTypes'
 import { LocalStorageManager } from '@/utils/LocalStorageManager'
 
 export class BranchManager {
@@ -37,7 +37,7 @@ export class BranchManager {
     const localStorage = LocalStorageManager.getInstance()
     const branches = localStorage.get('branches')
     if (branches) {
-      this.branches = JSON.parse(branches).map((branch: Branch) => this.loadBranch(branch))
+      this.branches = JSON.parse(branches).map((branch: any) => this.loadBranch(branch))
       if (this.branches.length > 10) {
         this.branches = this.branches.slice(-10)
       }
@@ -45,33 +45,24 @@ export class BranchManager {
     this.setLastId()
   }
 
-  private loadBranch(branch: Branch): Branch {
-    let projectId = branch.projectId || ''
-    let ticketId = branch.ticketId || ''
-
-    if (ticketId.includes('-') && !projectId) {
-      const splitIds = this.splitProjectAndTicketId(ticketId)
-      projectId = splitIds.projectId
-      ticketId = splitIds.ticketId
+  private loadBranch(data: any): Branch {
+    let branchName = data.branchName || ''
+    
+    // Retrocompatibilidad con datos antiguos guardados en localStorage
+    if (!branchName) {
+      const projectId = data.projectId ? `${data.projectId}-` : ''
+      const ticketId = data.ticketId || ''
+      const featureName = data.featureName ? `--${data.featureName}` : ''
+      branchName = `${projectId}${ticketId}${featureName}`
     }
 
-    const id = branch.id || 0
-    const featureName = branch.featureName || ''
+    const id = data.id || 0
 
     return new Branch({
-      id: id,
-      projectId: projectId.trim(),
-      ticketId: ticketId.trim(),
-      featureName: featureName.trim()
+      id,
+      branchName,
+      formatId: data.formatId
     })
-  }
-
-  private splitProjectAndTicketId(combinedId: string): { projectId: string; ticketId: string } {
-    const [projectId, ticketId] = combinedId.split('-')
-    return {
-      projectId: projectId || '',
-      ticketId: ticketId || ''
-    }
   }
 
   private setLastId(): void {
@@ -80,18 +71,15 @@ export class BranchManager {
     }, 0)
   }
 
-  public createBranch(formData: BranchFormType): void {
+  public createBranch(branchData: Omit<BranchType, 'id'>): void {
     this.setNewId()
     const newBranch = new Branch({
       id: this.lastId,
-      ticketId: formData.ticketId,
-      featureName: formData.featureName,
-      projectId: formData.projectId
+      branchName: branchData.branchName,
+      formatId: branchData.formatId
     })
     this.branches.push(newBranch)
-    // Limitar el historial a los 10 últimos registros (los de ID más alto / más recientes)
     if (this.branches.length > 10) {
-      // Como hacemos push, los más antiguos están al principio
       this.branches.shift()
     }
     this.saveBranches()
@@ -106,9 +94,9 @@ export class BranchManager {
     if (index !== -1) {
       this.branches.splice(index, 1)
       this.saveBranches()
-      return true // Indica que la rama fue eliminada
+      return true
     }
-    return false // Indica que la rama no existía
+    return false
   }
 
   private saveBranches(): void {

--- a/src/core/BranchTypes.ts
+++ b/src/core/BranchTypes.ts
@@ -1,10 +1,7 @@
-export interface BranchFormType {
-  projectId: string;
-  ticketId: string;
-  featureName: string;
-}
+export type BranchFormType = Record<string, string>;
 
-export interface BranchType extends BranchFormType {
+export interface BranchType {
   id: number;
-  branchName?: string;
+  branchName: string;
+  formatId?: string; // Optional: To know which format was used
 }

--- a/src/core/FormatManager.ts
+++ b/src/core/FormatManager.ts
@@ -1,0 +1,174 @@
+import type { BranchFormatTemplate } from '@/core/FormatTypes'
+
+export class FormatManager {
+  private static readonly STORAGE_KEY_CUSTOM = 'branch-formats-custom'
+  private static readonly STORAGE_KEY_HIDDEN_PREDEFINED = 'branch-formats-hidden'
+
+  private static readonly DEFAULT_FORMATS: BranchFormatTemplate[] = [
+    {
+      id: 'default-app',
+      name: 'Formato por defecto (App)',
+      templateString: '{projectId}-{ticketId}--{featureName}',
+      isReadonly: true,
+      isVisible: true,
+      fields: [
+        { id: 'projectId', label: 'ID Proyecto', operations: ['UPPERCASE', 'BASIC_CLEAN'] },
+        { id: 'ticketId', label: 'ID Ticket', operations: ['UPPERCASE', 'BASIC_CLEAN'] },
+        { id: 'featureName', label: 'Nombre Funcionalidad', operations: ['LOWERCASE', 'REPLACE_SLASHES', 'BASIC_CLEAN'] }
+      ]
+    },
+    {
+      id: 'gitflow',
+      name: 'GitFlow (feature/ticket-desc)',
+      templateString: 'feature/{ticketId}-{description}',
+      isReadonly: true,
+      isVisible: true,
+      fields: [
+        { id: 'ticketId', label: 'ID Ticket', operations: ['UPPERCASE', 'BASIC_CLEAN'] },
+        { id: 'description', label: 'Descripción', operations: ['LOWERCASE', 'BASIC_CLEAN'] }
+      ]
+    },
+    {
+      id: 'conventional-commits',
+      name: 'Conventional Commits',
+      templateString: '{type}/{scope}/{description}',
+      isReadonly: true,
+      isVisible: true,
+      fields: [
+        { id: 'type', label: 'Tipo (feat, fix...)', operations: ['LOWERCASE', 'BASIC_CLEAN'] },
+        { id: 'scope', label: 'Ámbito', operations: ['LOWERCASE', 'BASIC_CLEAN'] },
+        { id: 'description', label: 'Descripción', operations: ['LOWERCASE', 'BASIC_CLEAN'] }
+      ]
+    }
+  ]
+
+  static getFormats(): BranchFormatTemplate[] {
+    const customFormats = this.getCustomFormats()
+    const hiddenPredefined = this.getHiddenPredefinedIds()
+
+    const predefined = this.DEFAULT_FORMATS.map(format => ({
+      ...format,
+      isVisible: !hiddenPredefined.includes(format.id)
+    }))
+
+    return [...predefined, ...customFormats]
+  }
+
+  static getVisibleFormats(): BranchFormatTemplate[] {
+    return this.getFormats().filter(f => f.isVisible)
+  }
+
+  static getCustomFormats(): BranchFormatTemplate[] {
+    const data = localStorage.getItem(this.STORAGE_KEY_CUSTOM)
+    if (!data) return []
+    try {
+      return JSON.parse(data) as BranchFormatTemplate[]
+    } catch {
+      return []
+    }
+  }
+
+  private static saveCustomFormats(formats: BranchFormatTemplate[]): void {
+    localStorage.setItem(this.STORAGE_KEY_CUSTOM, JSON.stringify(formats))
+  }
+
+  private static getHiddenPredefinedIds(): string[] {
+    const data = localStorage.getItem(this.STORAGE_KEY_HIDDEN_PREDEFINED)
+    if (!data) return []
+    try {
+      return JSON.parse(data) as string[]
+    } catch {
+      return []
+    }
+  }
+
+  private static saveHiddenPredefinedIds(ids: string[]): void {
+    localStorage.setItem(this.STORAGE_KEY_HIDDEN_PREDEFINED, JSON.stringify(ids))
+  }
+
+  static addFormat(format: BranchFormatTemplate): void {
+    const custom = this.getCustomFormats()
+    // ensure it's not readonly
+    const newFormat = { ...format, isReadonly: false }
+    custom.push(newFormat)
+    this.saveCustomFormats(custom)
+  }
+
+  static updateFormat(updatedFormat: BranchFormatTemplate): void {
+    const custom = this.getCustomFormats()
+    const index = custom.findIndex(f => f.id === updatedFormat.id)
+    if (index !== -1) {
+      custom[index] = { ...updatedFormat, isReadonly: false }
+      this.saveCustomFormats(custom)
+    }
+  }
+
+  static deleteFormat(id: string): void {
+    const custom = this.getCustomFormats()
+    const filtered = custom.filter(f => f.id !== id)
+    this.saveCustomFormats(filtered)
+  }
+
+  static toggleVisibility(id: string): void {
+    const custom = this.getCustomFormats()
+    const customIndex = custom.findIndex(f => f.id === id)
+    
+    if (customIndex !== -1) {
+      custom[customIndex].isVisible = !custom[customIndex].isVisible
+      this.saveCustomFormats(custom)
+    } else {
+      // It might be a predefined format
+      const isPredefined = this.DEFAULT_FORMATS.some(f => f.id === id)
+      if (isPredefined) {
+        const hiddenIds = this.getHiddenPredefinedIds()
+        if (hiddenIds.includes(id)) {
+          this.saveHiddenPredefinedIds(hiddenIds.filter(hiddenId => hiddenId !== id))
+        } else {
+          hiddenIds.push(id)
+          this.saveHiddenPredefinedIds(hiddenIds)
+        }
+      }
+    }
+  }
+
+  static cloneFormat(id: string): BranchFormatTemplate | null {
+    const allFormats = this.getFormats()
+    const formatToClone = allFormats.find(f => f.id === id)
+    if (!formatToClone) return null
+
+    const newId = `custom-${Date.now()}`
+    const clonedFormat: BranchFormatTemplate = {
+      ...JSON.parse(JSON.stringify(formatToClone)), // Deep clone for fields
+      id: newId,
+      name: `${formatToClone.name} (Clon)`,
+      isReadonly: false,
+      isVisible: true
+    }
+    this.addFormat(clonedFormat)
+    return clonedFormat
+  }
+
+  static exportCustomFormats(): string {
+    return JSON.stringify(this.getCustomFormats(), null, 2)
+  }
+
+  static importCustomFormats(jsonString: string): void {
+    try {
+      const parsed = JSON.parse(jsonString) as BranchFormatTemplate[]
+      if (!Array.isArray(parsed)) throw new Error('Invalid format')
+      
+      const currentCustom = this.getCustomFormats()
+      // Create new IDs for imported to avoid collisions, or just append them if they look valid
+      const newFormats = parsed.map(f => ({
+        ...f,
+        id: `imported-${Date.now()}-${Math.random().toString(36).substring(2, 9)}`,
+        isReadonly: false
+      }))
+      
+      this.saveCustomFormats([...currentCustom, ...newFormats])
+    } catch (e) {
+      console.error('Error importing formats:', e)
+      throw e
+    }
+  }
+}

--- a/src/core/FormatManager.ts
+++ b/src/core/FormatManager.ts
@@ -1,48 +1,49 @@
-import type { BranchFormatTemplate } from '@/core/FormatTypes'
+import type { BranchFormatTemplate, LanguageProfile } from '@/core/FormatTypes'
 
 export class FormatManager {
   private static readonly STORAGE_KEY_CUSTOM = 'branch-formats-custom'
   private static readonly STORAGE_KEY_HIDDEN_PREDEFINED = 'branch-formats-hidden'
   private static readonly STORAGE_KEY_DEFAULT_FORMAT = 'branch-format-default-id'
+  private static readonly STORAGE_KEY_PREDEFINED_LANGUAGE = 'branch-formats-predefined-language'
 
   private static readonly DEFAULT_FORMATS: BranchFormatTemplate[] = [
     {
       id: 'default-app',
-      name: 'Formato por defecto (App)',
+      name: 'formats.defaultApp.name',
       templateString: '{projectId}-{ticketId}--{featureName}',
       isReadonly: true,
       isVisible: true,
       language: 'es',
       fields: [
-        { id: 'projectId', label: 'ID Proyecto', type: 'text', capitalization: 'UPPERCASE' },
-        { id: 'ticketId', label: 'ID Ticket', type: 'text', capitalization: 'UPPERCASE' },
-        { id: 'featureName', label: 'Nombre Funcionalidad', type: 'text', capitalization: 'LOWERCASE' }
+        { id: 'projectId', label: 'formats.defaultApp.projectId', type: 'text', capitalization: 'UPPERCASE' },
+        { id: 'ticketId', label: 'formats.defaultApp.ticketId', type: 'text', capitalization: 'UPPERCASE' },
+        { id: 'featureName', label: 'formats.defaultApp.featureName', type: 'text', capitalization: 'LOWERCASE' }
       ]
     },
     {
       id: 'gitflow',
-      name: 'GitFlow (type/ticket-desc)',
+      name: 'formats.gitflow.name',
       templateString: '{type}/{ticketId}-{description}',
       isReadonly: true,
       isVisible: true,
       language: 'es',
       fields: [
-        { id: 'type', label: 'Tipo', type: 'select', options: ['feature', 'bugfix', 'hotfix', 'release', 'chore'], capitalization: 'LOWERCASE' },
-        { id: 'ticketId', label: 'ID Ticket', type: 'text', capitalization: 'UPPERCASE' },
-        { id: 'description', label: 'Descripción', type: 'text', capitalization: 'LOWERCASE' }
+        { id: 'type', label: 'formats.gitflow.type', type: 'select', options: ['feature', 'bugfix', 'hotfix', 'release', 'chore'], capitalization: 'LOWERCASE' },
+        { id: 'ticketId', label: 'formats.gitflow.ticketId', type: 'text', capitalization: 'UPPERCASE' },
+        { id: 'description', label: 'formats.gitflow.description', type: 'text', capitalization: 'LOWERCASE' }
       ]
     },
     {
       id: 'conventional-commits',
-      name: 'Conventional Commits',
+      name: 'formats.conventionalCommits.name',
       templateString: '{type}/{scope}/{description}',
       isReadonly: true,
       isVisible: true,
       language: 'es',
       fields: [
-        { id: 'type', label: 'Tipo (feat, fix...)', type: 'select', options: ['feat', 'fix', 'docs', 'style', 'refactor', 'perf', 'test', 'build', 'ci', 'chore', 'revert'], capitalization: 'LOWERCASE' },
-        { id: 'scope', label: 'Ámbito', type: 'text', capitalization: 'LOWERCASE' },
-        { id: 'description', label: 'Descripción', type: 'text', capitalization: 'LOWERCASE' }
+        { id: 'type', label: 'formats.conventionalCommits.type', type: 'select', options: ['feat', 'fix', 'docs', 'style', 'refactor', 'perf', 'test', 'build', 'ci', 'chore', 'revert'], capitalization: 'LOWERCASE' },
+        { id: 'scope', label: 'formats.conventionalCommits.scope', type: 'text', capitalization: 'LOWERCASE' },
+        { id: 'description', label: 'formats.conventionalCommits.description', type: 'text', capitalization: 'LOWERCASE' }
       ]
     }
   ]
@@ -50,10 +51,12 @@ export class FormatManager {
   static getFormats(): BranchFormatTemplate[] {
     const customFormats = this.getCustomFormats()
     const hiddenPredefined = this.getHiddenPredefinedIds()
+    const languageOverrides = this.getPredefinedLanguageOverrides()
 
     const predefined = this.DEFAULT_FORMATS.map(format => ({
       ...format,
-      isVisible: !hiddenPredefined.includes(format.id)
+      isVisible: !hiddenPredefined.includes(format.id),
+      language: languageOverrides[format.id] ?? format.language
     }))
 
     return [...predefined, ...customFormats]
@@ -97,6 +100,20 @@ export class FormatManager {
 
   private static saveHiddenPredefinedIds(ids: string[]): void {
     localStorage.setItem(this.STORAGE_KEY_HIDDEN_PREDEFINED, JSON.stringify(ids))
+  }
+
+  private static getPredefinedLanguageOverrides(): Partial<Record<string, LanguageProfile>> {
+    const data = localStorage.getItem(this.STORAGE_KEY_PREDEFINED_LANGUAGE)
+    if (!data) return {}
+    try {
+      return JSON.parse(data) as Partial<Record<string, LanguageProfile>>
+    } catch {
+      return {}
+    }
+  }
+
+  private static savePredefinedLanguageOverrides(overrides: Partial<Record<string, LanguageProfile>>): void {
+    localStorage.setItem(this.STORAGE_KEY_PREDEFINED_LANGUAGE, JSON.stringify(overrides))
   }
 
   static addFormat(format: BranchFormatTemplate): void {
@@ -151,18 +168,44 @@ export class FormatManager {
     }
   }
 
-  static cloneFormat(id: string): BranchFormatTemplate | null {
+  // Único ajuste editable en un formato predefinido (además de visible/predeterminado):
+  // el idioma usado para el saneado de caracteres.
+  static setLanguage(id: string, language: LanguageProfile): void {
+    const custom = this.getCustomFormats()
+    const customIndex = custom.findIndex(f => f.id === id)
+
+    if (customIndex !== -1) {
+      custom[customIndex].language = language
+      this.saveCustomFormats(custom)
+      return
+    }
+
+    const isPredefined = this.DEFAULT_FORMATS.some(f => f.id === id)
+    if (isPredefined) {
+      const overrides = this.getPredefinedLanguageOverrides()
+      overrides[id] = language
+      this.savePredefinedLanguageOverrides(overrides)
+    }
+  }
+
+  static cloneFormat(id: string, resolveLabel: (value: string) => string, cloneSuffix: string): BranchFormatTemplate | null {
     const allFormats = this.getFormats()
     const formatToClone = allFormats.find(f => f.id === id)
     if (!formatToClone) return null
 
+    // Al clonar, se "hornean" los textos traducidos (nombre y etiquetas de campo):
+    // el clon es un formato normal editable, no debe seguir arrastrando claves i18n.
     const newId = `custom-${Date.now()}`
     const clonedFormat: BranchFormatTemplate = {
       ...JSON.parse(JSON.stringify(formatToClone)), // Deep clone for fields
       id: newId,
-      name: `${formatToClone.name} (Clon)`,
+      name: `${resolveLabel(formatToClone.name)} ${cloneSuffix}`,
       isReadonly: false,
-      isVisible: true
+      isVisible: true,
+      fields: formatToClone.fields.map(field => ({
+        ...field,
+        label: resolveLabel(field.label)
+      }))
     }
     this.addFormat(clonedFormat)
     return clonedFormat
@@ -176,7 +219,7 @@ export class FormatManager {
     try {
       const parsed = JSON.parse(jsonString) as BranchFormatTemplate[]
       if (!Array.isArray(parsed)) throw new Error('Invalid format')
-      
+
       const currentCustom = this.getCustomFormats()
       // Create new IDs for imported to avoid collisions, or just append them if they look valid
       const newFormats = parsed.map(f => ({
@@ -184,7 +227,7 @@ export class FormatManager {
         id: `imported-${Date.now()}-${Math.random().toString(36).substring(2, 9)}`,
         isReadonly: false
       }))
-      
+
       this.saveCustomFormats([...currentCustom, ...newFormats])
     } catch (e) {
       console.error('Error importing formats:', e)

--- a/src/core/FormatManager.ts
+++ b/src/core/FormatManager.ts
@@ -3,6 +3,7 @@ import type { BranchFormatTemplate } from '@/core/FormatTypes'
 export class FormatManager {
   private static readonly STORAGE_KEY_CUSTOM = 'branch-formats-custom'
   private static readonly STORAGE_KEY_HIDDEN_PREDEFINED = 'branch-formats-hidden'
+  private static readonly STORAGE_KEY_DEFAULT_FORMAT = 'branch-format-default-id'
 
   private static readonly DEFAULT_FORMATS: BranchFormatTemplate[] = [
     {
@@ -11,21 +12,24 @@ export class FormatManager {
       templateString: '{projectId}-{ticketId}--{featureName}',
       isReadonly: true,
       isVisible: true,
+      language: 'es',
       fields: [
-        { id: 'projectId', label: 'ID Proyecto', operations: ['UPPERCASE', 'BASIC_CLEAN'] },
-        { id: 'ticketId', label: 'ID Ticket', operations: ['UPPERCASE', 'BASIC_CLEAN'] },
-        { id: 'featureName', label: 'Nombre Funcionalidad', operations: ['LOWERCASE', 'REPLACE_SLASHES', 'BASIC_CLEAN'] }
+        { id: 'projectId', label: 'ID Proyecto', type: 'text', capitalization: 'UPPERCASE' },
+        { id: 'ticketId', label: 'ID Ticket', type: 'text', capitalization: 'UPPERCASE' },
+        { id: 'featureName', label: 'Nombre Funcionalidad', type: 'text', capitalization: 'LOWERCASE' }
       ]
     },
     {
       id: 'gitflow',
-      name: 'GitFlow (feature/ticket-desc)',
-      templateString: 'feature/{ticketId}-{description}',
+      name: 'GitFlow (type/ticket-desc)',
+      templateString: '{type}/{ticketId}-{description}',
       isReadonly: true,
       isVisible: true,
+      language: 'es',
       fields: [
-        { id: 'ticketId', label: 'ID Ticket', operations: ['UPPERCASE', 'BASIC_CLEAN'] },
-        { id: 'description', label: 'Descripción', operations: ['LOWERCASE', 'BASIC_CLEAN'] }
+        { id: 'type', label: 'Tipo', type: 'select', options: ['feature', 'bugfix', 'hotfix', 'release', 'chore'], capitalization: 'LOWERCASE' },
+        { id: 'ticketId', label: 'ID Ticket', type: 'text', capitalization: 'UPPERCASE' },
+        { id: 'description', label: 'Descripción', type: 'text', capitalization: 'LOWERCASE' }
       ]
     },
     {
@@ -34,10 +38,11 @@ export class FormatManager {
       templateString: '{type}/{scope}/{description}',
       isReadonly: true,
       isVisible: true,
+      language: 'es',
       fields: [
-        { id: 'type', label: 'Tipo (feat, fix...)', operations: ['LOWERCASE', 'BASIC_CLEAN'] },
-        { id: 'scope', label: 'Ámbito', operations: ['LOWERCASE', 'BASIC_CLEAN'] },
-        { id: 'description', label: 'Descripción', operations: ['LOWERCASE', 'BASIC_CLEAN'] }
+        { id: 'type', label: 'Tipo (feat, fix...)', type: 'select', options: ['feat', 'fix', 'docs', 'style', 'refactor', 'perf', 'test', 'build', 'ci', 'chore', 'revert'], capitalization: 'LOWERCASE' },
+        { id: 'scope', label: 'Ámbito', type: 'text', capitalization: 'LOWERCASE' },
+        { id: 'description', label: 'Descripción', type: 'text', capitalization: 'LOWERCASE' }
       ]
     }
   ]
@@ -56,6 +61,14 @@ export class FormatManager {
 
   static getVisibleFormats(): BranchFormatTemplate[] {
     return this.getFormats().filter(f => f.isVisible)
+  }
+
+  static getDefaultFormatId(): string | null {
+    return localStorage.getItem(this.STORAGE_KEY_DEFAULT_FORMAT)
+  }
+
+  static setDefaultFormatId(id: string): void {
+    localStorage.setItem(this.STORAGE_KEY_DEFAULT_FORMAT, id)
   }
 
   static getCustomFormats(): BranchFormatTemplate[] {
@@ -110,20 +123,27 @@ export class FormatManager {
   }
 
   static toggleVisibility(id: string): void {
+    const current = this.getFormats().find(f => f.id === id)
+    if (!current) return
+    this.setVisibility(id, !current.isVisible)
+  }
+
+  static setVisibility(id: string, visible: boolean): void {
     const custom = this.getCustomFormats()
     const customIndex = custom.findIndex(f => f.id === id)
-    
+
     if (customIndex !== -1) {
-      custom[customIndex].isVisible = !custom[customIndex].isVisible
+      custom[customIndex].isVisible = visible
       this.saveCustomFormats(custom)
     } else {
       // It might be a predefined format
       const isPredefined = this.DEFAULT_FORMATS.some(f => f.id === id)
       if (isPredefined) {
         const hiddenIds = this.getHiddenPredefinedIds()
-        if (hiddenIds.includes(id)) {
+        const isCurrentlyHidden = hiddenIds.includes(id)
+        if (visible && isCurrentlyHidden) {
           this.saveHiddenPredefinedIds(hiddenIds.filter(hiddenId => hiddenId !== id))
-        } else {
+        } else if (!visible && !isCurrentlyHidden) {
           hiddenIds.push(id)
           this.saveHiddenPredefinedIds(hiddenIds)
         }

--- a/src/core/FormatTypes.ts
+++ b/src/core/FormatTypes.ts
@@ -1,19 +1,14 @@
-export type FormatOperation =
-  | 'UPPERCASE'
-  | 'LOWERCASE'
-  | 'REPLACE_SLASHES' // replace '/' with '-o-'
-  | 'REPLACE_DOTS' // replace '.' with '-'
-  | 'REPLACE_SPACES' // replace ' ' with '-'
-  | 'REMOVE_MULTIPLE_DASHES'
-  | 'SET_NY' // replace 'ñ' with 'ny'
-  | 'REMOVE_ACCENTS'
-  | 'REMOVE_SPECIAL_CHARS' // remove everything except a-zA-Z0-9-
-  | 'BASIC_CLEAN'; // combination of replace dots, spaces, multiple dashes and special chars
+export type Capitalization = 'UPPERCASE' | 'LOWERCASE' | 'AS_IS';
+
+// Mismos idiomas que el selector de idioma de la app (LangSelector)
+export type LanguageProfile = 'en' | 'es' | 'fr' | 'de' | 'it' | 'pt';
 
 export interface FieldDefinition {
   id: string;
   label: string; // The UI label or i18n key for the form field
-  operations: FormatOperation[];
+  capitalization: Capitalization;
+  type?: 'text' | 'select';
+  options?: string[];
 }
 
 export interface BranchFormatTemplate {
@@ -21,6 +16,7 @@ export interface BranchFormatTemplate {
   name: string;
   templateString: string;
   fields: FieldDefinition[];
+  language: LanguageProfile; // Idioma usado para el saneado de caracteres (ñ, /, etc.)
   isReadonly: boolean;
   isVisible: boolean;
 }

--- a/src/core/FormatTypes.ts
+++ b/src/core/FormatTypes.ts
@@ -1,0 +1,26 @@
+export type FormatOperation =
+  | 'UPPERCASE'
+  | 'LOWERCASE'
+  | 'REPLACE_SLASHES' // replace '/' with '-o-'
+  | 'REPLACE_DOTS' // replace '.' with '-'
+  | 'REPLACE_SPACES' // replace ' ' with '-'
+  | 'REMOVE_MULTIPLE_DASHES'
+  | 'SET_NY' // replace 'ñ' with 'ny'
+  | 'REMOVE_ACCENTS'
+  | 'REMOVE_SPECIAL_CHARS' // remove everything except a-zA-Z0-9-
+  | 'BASIC_CLEAN'; // combination of replace dots, spaces, multiple dashes and special chars
+
+export interface FieldDefinition {
+  id: string;
+  label: string; // The UI label or i18n key for the form field
+  operations: FormatOperation[];
+}
+
+export interface BranchFormatTemplate {
+  id: string;
+  name: string;
+  templateString: string;
+  fields: FieldDefinition[];
+  isReadonly: boolean;
+  isVisible: boolean;
+}

--- a/src/core/__tests__/Branch.spec.ts
+++ b/src/core/__tests__/Branch.spec.ts
@@ -1,74 +1,18 @@
-import { describe, it, expect } from 'vitest'
-import { Branch } from '../../core/Branch'
-import type { BranchType } from '../../core/BranchTypes'
+import { describe, expect, it } from 'vitest'
+import { Branch } from '../Branch'
 
 describe('Branch', () => {
   it('should create a Branch instance with formatted branchName', () => {
-    const branchData: BranchType = {
+    const branchData = {
       id: 1,
-      projectId: 'PROJ',
-      ticketId: 'TICKET-123',
-      featureName: 'New Feature'
+      branchName: 'PROJ-TICKET-123--New-Feature',
+      formatId: 'default'
     }
 
     const branch = new Branch(branchData)
 
     expect(branch.id).toBe(1)
-    expect(branch.projectId).toBe('PROJ')
-    expect(branch.ticketId).toBe('TICKET-123')
-    expect(branch.featureName).toBe('New Feature')
-    expect(branch.branchName).toBe('PROJ-TICKET-123--new-feature')
-  })
-
-  it('should format the branchName correctly', () => {
-    const branchData: BranchType = {
-      id: 2,
-      projectId: 'PROJ',
-      ticketId: 'TICKET-456',
-      featureName: 'Another Feature'
-    }
-
-    const branch = new Branch(branchData)
-
-    expect(branch.branchName).toBe('PROJ-TICKET-456--another-feature')
-  })
-
-  it('should handle special characters in featureName', () => {
-    const branchData: BranchType = {
-      id: 3,
-      projectId: 'PROJ',
-      ticketId: 'TICKET-789',
-      featureName: 'Feature with Special Characters!@#'
-    }
-
-    const branch = new Branch(branchData)
-
-    expect(branch.branchName).toBe('PROJ-TICKET-789--feature-with-special-characters')
-  })
-
-  it('should handle spaces in featureName', () => {
-    const branchData: BranchType = {
-      id: 4,
-      projectId: 'PROJ',
-      ticketId: 'TICKET-101',
-      featureName: 'Feature with spaces'
-    }
-
-    const branch = new Branch(branchData)
-
-    expect(branch.branchName).toBe('PROJ-TICKET-101--feature-with-spaces')
-  })
-
-  it('should handle multiple dashes in featureName', () => {
-    const branchData: BranchType = {
-      id: 5,
-      projectId: 'PROJ',
-      ticketId: 'TICKET-202',
-      featureName: 'Feature---with---multiple---dashes'
-    }
-
-    const branch = new Branch(branchData)
-
-    expect(branch.branchName).toBe('PROJ-TICKET-202--feature-with-multiple-dashes')
+    expect(branch.branchName).toBe('PROJ-TICKET-123--New-Feature')
+    expect(branch.formatId).toBe('default')
   })
 })

--- a/src/core/__tests__/BranchFormatter.spec.ts
+++ b/src/core/__tests__/BranchFormatter.spec.ts
@@ -9,14 +9,15 @@ describe('BranchFormatter', () => {
     templateString: '{projectId}-{ticketId}--{featureName}',
     isReadonly: true,
     isVisible: true,
+    language: 'es',
     fields: [
-      { id: 'projectId', label: 'ID', operations: ['UPPERCASE', 'BASIC_CLEAN'] },
-      { id: 'ticketId', label: 'TICKET', operations: ['UPPERCASE', 'BASIC_CLEAN'] },
-      { id: 'featureName', label: 'FEATURE', operations: ['LOWERCASE', 'REPLACE_SLASHES', 'BASIC_CLEAN'] }
+      { id: 'projectId', label: 'ID', capitalization: 'UPPERCASE' },
+      { id: 'ticketId', label: 'TICKET', capitalization: 'UPPERCASE' },
+      { id: 'featureName', label: 'FEATURE', capitalization: 'LOWERCASE' }
     ]
   }
 
-  it('should apply operations correctly', () => {
+  it('should sanitize and apply capitalization correctly', () => {
     const values = {
       projectId: 'proj',
       ticketId: 't-123',
@@ -36,7 +37,7 @@ describe('BranchFormatter', () => {
     expect(result).toBe('PROJ-123--my-feature')
   })
 
-  it('should replace ñ and accents', () => {
+  it('should replace ñ and accents (es)', () => {
     const values = {
       projectId: 'prój',
       ticketId: 'tíckët',
@@ -44,5 +45,32 @@ describe('BranchFormatter', () => {
     }
     const result = BranchFormatter.format(dummyTemplate, values)
     expect(result).toBe('PROJ-TICKET--ninyo')
+  })
+
+  it('should respect AS_IS capitalization', () => {
+    const template: BranchFormatTemplate = {
+      ...dummyTemplate,
+      fields: [
+        { id: 'projectId', label: 'ID', capitalization: 'AS_IS' },
+        { id: 'ticketId', label: 'TICKET', capitalization: 'AS_IS' },
+        { id: 'featureName', label: 'FEATURE', capitalization: 'AS_IS' }
+      ]
+    }
+    const result = BranchFormatter.format(template, {
+      projectId: 'Proj',
+      ticketId: 'T-123',
+      featureName: 'MixedCase'
+    })
+    expect(result).toBe('Proj-T-123--MixedCase')
+  })
+
+  it('should use the language profile to translate the slash word', () => {
+    const template: BranchFormatTemplate = { ...dummyTemplate, language: 'en' }
+    const result = BranchFormatter.format(template, {
+      projectId: 'proj',
+      ticketId: '1',
+      featureName: 'a/b'
+    })
+    expect(result).toBe('PROJ-1--a-or-b')
   })
 })

--- a/src/core/__tests__/BranchFormatter.spec.ts
+++ b/src/core/__tests__/BranchFormatter.spec.ts
@@ -73,4 +73,31 @@ describe('BranchFormatter', () => {
     })
     expect(result).toBe('PROJ-1--a-or-b')
   })
+
+  it.each([
+    ['es', 'o'],
+    ['en', 'or'],
+    ['fr', 'ou'],
+    ['de', 'oder'],
+    ['it', 'o'],
+    ['pt', 'ou']
+  ] as const)('translates "/" to "-%s-" for language %s', (language, slashWord) => {
+    const template: BranchFormatTemplate = { ...dummyTemplate, language }
+    const result = BranchFormatter.format(template, {
+      projectId: 'proj',
+      ticketId: '1',
+      featureName: 'a/b'
+    })
+    expect(result).toBe(`PROJ-1--a-${slashWord}-b`)
+  })
+
+  it('should replace ß with ss (de)', () => {
+    const template: BranchFormatTemplate = { ...dummyTemplate, language: 'de' }
+    const result = BranchFormatter.format(template, {
+      projectId: 'proj',
+      ticketId: '1',
+      featureName: 'straße/api'
+    })
+    expect(result).toBe('PROJ-1--strasse-oder-api')
+  })
 })

--- a/src/core/__tests__/BranchFormatter.spec.ts
+++ b/src/core/__tests__/BranchFormatter.spec.ts
@@ -1,106 +1,48 @@
-import { describe, it, expect } from 'vitest'
-import { BranchFormatter } from '../../core/BranchFormatter'
-import type { BranchType } from '../../core/BranchTypes'
+import { describe, expect, it } from 'vitest'
+import { BranchFormatter } from '../BranchFormatter'
+import type { BranchFormatTemplate } from '../FormatTypes'
 
 describe('BranchFormatter', () => {
-  it('should format branch name correctly', () => {
-    const branch: BranchType = {
+  const dummyTemplate: BranchFormatTemplate = {
+    id: 'test',
+    name: 'Test',
+    templateString: '{projectId}-{ticketId}--{featureName}',
+    isReadonly: true,
+    isVisible: true,
+    fields: [
+      { id: 'projectId', label: 'ID', operations: ['UPPERCASE', 'BASIC_CLEAN'] },
+      { id: 'ticketId', label: 'TICKET', operations: ['UPPERCASE', 'BASIC_CLEAN'] },
+      { id: 'featureName', label: 'FEATURE', operations: ['LOWERCASE', 'REPLACE_SLASHES', 'BASIC_CLEAN'] }
+    ]
+  }
+
+  it('should apply operations correctly', () => {
+    const values = {
+      projectId: 'proj',
+      ticketId: 't-123',
+      featureName: 'My/Feature Name'
+    }
+    const result = BranchFormatter.format(dummyTemplate, values)
+    expect(result).toBe('PROJ-T-123--my-o-feature-name')
+  })
+
+  it('should remove multiple dashes', () => {
+    const values = {
       projectId: 'PROJ',
-      ticketId: 'TICKET-123',
-      featureName: 'New Feature'
-    } as BranchType
-
-    const formattedName = BranchFormatter.format(branch)
-
-    expect(formattedName).toBe('PROJ-TICKET-123--new-feature')
+      ticketId: '123',
+      featureName: 'my----feature'
+    }
+    const result = BranchFormatter.format(dummyTemplate, values)
+    expect(result).toBe('PROJ-123--my-feature')
   })
 
-  it('should handle special characters in featureName', () => {
-    const branch: BranchType = {
-      projectId: 'PROJ',
-      ticketId: 'TICKET-456',
-      featureName: 'Feature with Special Characters!@#'
-    } as BranchType
-
-    const formattedName = BranchFormatter.format(branch)
-
-    expect(formattedName).toBe('PROJ-TICKET-456--feature-with-special-characters')
-  })
-
-  it('should handle spaces in featureName', () => {
-    const branch: BranchType = {
-      ticketId: 'TICKET-789',
-      featureName: 'Feature with spaces'
-    } as BranchType
-
-    const formattedName = BranchFormatter.format(branch)
-
-    expect(formattedName).toBe('TICKET-789--feature-with-spaces')
-  })
-
-  it('should handle multiple dashes in featureName', () => {
-    const branch: BranchType = {
-      ticketId: 'TICKET-101',
-      featureName: 'Feature---with---multiple---dashes'
-    } as BranchType
-
-    const formattedName = BranchFormatter.format(branch)
-
-    expect(formattedName).toBe('TICKET-101--feature-with-multiple-dashes')
-  })
-
-  it('should convert ticketId to uppercase', () => {
-    const branch: BranchType = {
-      ticketId: 'ticket-202',
-      featureName: 'Feature'
-    } as BranchType
-
-    const formattedName = BranchFormatter.format(branch)
-
-    expect(formattedName).toBe('TICKET-202--feature')
-  })
-
-  it('should convert ñ to ny', () => {
-    const branch: BranchType = {
-      ticketId: 'ticket-303',
-      featureName: 'Año nuevo'
-    } as BranchType
-
-    const formattedName = BranchFormatter.format(branch)
-
-    expect(formattedName).toBe('TICKET-303--anyo-nuevo')
-  })
-
-  it('should remove accents', () => {
-    const branch: BranchType = {
-      ticketId: 'ticket-404',
-      featureName: 'Áccentéd fëatüre'
-    } as BranchType
-
-    const formattedName = BranchFormatter.format(branch)
-
-    expect(formattedName).toBe('TICKET-404--accented-feature')
-  })
-
-  it('should replace slashes with -o-', () => {
-    const branch: BranchType = {
-      ticketId: 'ticket-505',
-      featureName: 'Feature/slashes'
-    } as BranchType
-
-    const formattedName = BranchFormatter.format(branch)
-
-    expect(formattedName).toBe('TICKET-505--feature-o-slashes')
-  })
-
-  it('should replace dots with dashes', () => {
-    const branch: BranchType = {
-      ticketId: 'ticket-606',
-      featureName: 'version 5.1.0'
-    } as BranchType
-
-    const formattedName = BranchFormatter.format(branch)
-
-    expect(formattedName).toBe('TICKET-606--version-5-1-0')
+  it('should replace ñ and accents', () => {
+    const values = {
+      projectId: 'prój',
+      ticketId: 'tíckët',
+      featureName: 'niño'
+    }
+    const result = BranchFormatter.format(dummyTemplate, values)
+    expect(result).toBe('PROJ-TICKET--ninyo')
   })
 })

--- a/src/core/__tests__/BranchManager.spec.ts
+++ b/src/core/__tests__/BranchManager.spec.ts
@@ -1,219 +1,89 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest'
-import { BranchManager } from '../../core/BranchManager'
-import type { BranchFormType } from '../../core/BranchTypes'
-import { LocalStorageManager } from '../../utils/LocalStorageManager'
-import { Branch } from '@/core/Branch'
-
-const mockBranches = [
-  new Branch({ id: 1, projectId: 'PRJ', ticketId: '123', featureName: 'feature-a' }),
-  new Branch({ id: 2, projectId: 'PRJ', ticketId: '124', featureName: 'feature-b' }),
-  new Branch({ id: 3, projectId: 'PRJ2', ticketId: '125', featureName: 'feature-c' }),
-  new Branch({ id: 4, projectId: 'PRJ2', ticketId: '126', featureName: 'feature-d' })
-]
-
-const branchManager = BranchManager.getInstance()
-branchManager['branches'] = mockBranches
+import { beforeEach, describe, expect, it } from 'vitest'
+import { BranchManager } from '../BranchManager'
 
 describe('BranchManager', () => {
+  let manager: BranchManager
+
   beforeEach(() => {
-    const manager = BranchManager.getInstance()
+    localStorage.clear()
+    manager = BranchManager.getInstance()
     manager.clearBranches()
   })
 
-  it('should initialize with an empty list of branches', () => {
-    const manager = BranchManager.getInstance()
-    expect(manager.getBranches()).toEqual([])
+  it('should be a singleton', () => {
+    const manager2 = BranchManager.getInstance()
+    expect(manager).toBe(manager2)
   })
 
   it('should add a new branch', () => {
-    const manager = BranchManager.getInstance()
-    const formData: BranchFormType = {
-      projectId: 'PROJ',
-      ticketId: 'TICKET-123',
-      featureName: 'New Feature'
-    }
-
-    manager.createBranch(formData)
-
+    manager.createBranch({
+      branchName: 'PROJ-123--new-feature',
+      formatId: 'default'
+    })
+    
     const branches = manager.getBranches()
     expect(branches).toHaveLength(1)
-    expect(branches[0].projectId).toBe('PROJ')
-    expect(branches[0].ticketId).toBe('TICKET-123')
-    expect(branches[0].featureName).toBe('New Feature')
-    expect(branches[0].branchName).toBe('PROJ-TICKET-123--new-feature')
+    expect(branches[0].branchName).toBe('PROJ-123--new-feature')
   })
 
-  it('should remove a branch', () => {
-    const manager = BranchManager.getInstance()
-    const formData: BranchFormType = {
-      projectId: 'PROJ',
-      ticketId: 'TICKET-123',
-      featureName: 'New Feature'
-    }
-
-    manager.createBranch(formData)
-    const branchToDelete = manager.getBranches()[0]
-
-    manager.deleteBranch(branchToDelete.id)
-
-    expect(manager.getBranches()).toHaveLength(0)
-  })
-
-  it('should not remove a branch if it does not exist', () => {
-    const manager = BranchManager.getInstance()
-    const formData: BranchFormType = {
-      projectId: 'PROJ',
-      ticketId: 'TICKET-123',
-      featureName: 'New Feature'
-    }
-
-    manager.createBranch(formData)
-    const nonExistentBranchId = 999
-
-    const result = manager.deleteBranch(nonExistentBranchId)
-
-    expect(result).toBe(false) // Verifica que no se eliminó ninguna rama
-    expect(manager.getBranches()).toHaveLength(1) // Asegura que la rama original sigue existiendo
-  })
-
-  it('shoulf sort branches in ascending order', () => {
-    const manager = BranchManager.getInstance()
-    manager.clearBranches()
-
-    const formData1: BranchFormType = {
-      projectId: 'PROJ',
-      ticketId: 'TICKET-123',
-      featureName: 'New Feature'
-    }
-    const formData2: BranchFormType = {
-      projectId: 'PROJ',
-      ticketId: 'TICKET-456',
-      featureName: 'Another Feature'
-    }
-
-    manager.createBranch(formData2)
-    manager.createBranch(formData1)
+  it('should sort branches in ascending order', () => {
+    manager.createBranch({ branchName: 'B1' })
+    manager.createBranch({ branchName: 'B2' })
 
     const branches = manager.getBranches(false)
-    expect(branches[0].ticketId).toBe('TICKET-456')
-    expect(branches[1].ticketId).toBe('TICKET-123')
+    expect(branches[0].branchName).toBe('B1')
+    expect(branches[1].branchName).toBe('B2')
   })
 
   it('should sort branches in descending order', () => {
-    const manager = BranchManager.getInstance()
-    manager.clearBranches()
-
-    const formData1: BranchFormType = {
-      projectId: 'PROJ',
-      ticketId: 'TICKET-123',
-      featureName: 'New Feature'
-    }
-    const formData2: BranchFormType = {
-      projectId: 'PROJ',
-      ticketId: 'TICKET-456',
-      featureName: 'Another Feature'
-    }
-
-    manager.createBranch(formData2)
-    manager.createBranch(formData1)
+    manager.createBranch({ branchName: 'B1' })
+    manager.createBranch({ branchName: 'B2' })
 
     const branches = manager.getBranches()
-    expect(branches[0].ticketId).toBe('TICKET-123')
-    expect(branches[1].ticketId).toBe('TICKET-456')
+    expect(branches[0].branchName).toBe('B2')
+    expect(branches[1].branchName).toBe('B1')
   })
 
-  it('should not repeat branch ids', () => {
-    const manager = BranchManager.getInstance()
-    manager.clearBranches()
-
-    const formData1: BranchFormType = {
-      projectId: 'PROJ',
-      ticketId: 'TICKET-123',
-      featureName: 'New Feature'
+  it('should keep only the last 10 branches', () => {
+    for (let i = 0; i < 15; i++) {
+      manager.createBranch({ branchName: `B${i}` })
     }
-    const formData2: BranchFormType = {
-      projectId: 'PROJ',
-      ticketId: 'TICKET-456',
-      featureName: 'Another Feature'
-    }
-    const formData3: BranchFormType = {
-      projectId: 'PROJ',
-      ticketId: 'TICKET-789',
-      featureName: 'Yet Another Feature'
-    }
-
-    manager.createBranch(formData1)
-    manager.createBranch(formData2)
-    manager.deleteBranch(1)
-    manager.createBranch(formData3)
 
     const branches = manager.getBranches()
-    expect(branches[0].id).not.toBe(branches[1].id)
+    expect(branches).toHaveLength(10)
+    // The most recent ones (highest IDs) should be kept
+    expect(branches[0].branchName).toBe('B14')
+    expect(branches[9].branchName).toBe('B5')
   })
 
-  it('should correct a branch name during load from local storage', () => {
-    const manager = BranchManager.getInstance()
-    manager.clearBranches()
-
-    // Simulate local storage with a combined projectId and ticketId in ticketId field
-    const localStorageMock = {
-      get: (key: string) => {
-        if (key === 'branches') {
-          return JSON.stringify([
-            {
-              id: 1,
-              ticketId: 'PROJECT-123',
-              featureName: 'Feature Name',
-              projectId: ''
-            }
-          ])
-        }
-        return null
-      },
-      save: () => {}
-    }
-
-    vi.spyOn(LocalStorageManager, 'getInstance').mockReturnValue(localStorageMock as any)
-
-    manager['loadBranches']()
-
+  it('should delete a branch', () => {
+    manager.createBranch({ branchName: 'B1' })
     const branches = manager.getBranches()
+    const id = branches[0].id
+
+    const deleted = manager.deleteBranch(id)
+    expect(deleted).toBe(true)
+    expect(manager.getBranches()).toHaveLength(0)
+  })
+
+  it('should maintain retrocompatibility with old branch format in localstorage', () => {
+    localStorage.setItem('branches', JSON.stringify([{
+      id: 1,
+      projectId: 'OLD',
+      ticketId: '123',
+      featureName: 'feature'
+    }]))
+
+    // need to recreate manager to force load
+    const tempManager = (BranchManager as any).instance
+    ;(BranchManager as any).instance = undefined
+    const newManager = BranchManager.getInstance()
+
+    const branches = newManager.getBranches()
     expect(branches).toHaveLength(1)
-    expect(branches[0].projectId).toBe('PROJECT')
-    expect(branches[0].ticketId).toBe('123')
-    expect(branches[0].featureName).toBe('Feature Name')
-  })
-
-  it('should correctly handle a branch with a hyphen in the ticketId and a valid projectId', () => {
-    const manager = BranchManager.getInstance()
-    manager.clearBranches()
-
-    // Simulate local storage with a branch having a hyphen in ticketId and a valid projectId
-    const localStorageMock = {
-      get: (key: string) => {
-        if (key === 'branches') {
-          return JSON.stringify([
-            {
-              id: 1,
-              ticketId: 'TICKET-123-456',
-              featureName: 'Feature Name',
-              projectId: 'PROJ'
-            }
-          ])
-        }
-        return null
-      },
-      save: () => {}
-    }
-
-    vi.spyOn(LocalStorageManager, 'getInstance').mockReturnValue(localStorageMock as any)
-
-    manager['loadBranches']()
-
-    const branches = manager.getBranches()
-    expect(branches).toHaveLength(1)
-    expect(branches[0].projectId).toBe('PROJ') // Ensure projectId is not overwritten
-    expect(branches[0].ticketId).toBe('TICKET-123-456') // Ensure ticketId remains intact
-    expect(branches[0].featureName).toBe('Feature Name')
+    expect(branches[0].branchName).toBe('OLD-123--feature')
+    
+    // restore instance
+    ;(BranchManager as any).instance = tempManager
   })
 })

--- a/src/core/__tests__/FormatManager.spec.ts
+++ b/src/core/__tests__/FormatManager.spec.ts
@@ -44,8 +44,9 @@ describe('FormatManager', () => {
       templateString: '{customField}',
       isReadonly: false,
       isVisible: true,
+      language: 'es',
       fields: [
-        { id: 'customField', label: 'Custom Field', type: 'select', options: ['A', 'B'], operations: [] }
+        { id: 'customField', label: 'Custom Field', type: 'select', options: ['A', 'B'], capitalization: 'AS_IS' }
       ]
     }
     
@@ -70,6 +71,7 @@ describe('FormatManager', () => {
       templateString: '',
       isReadonly: false,
       isVisible: true,
+      language: 'es',
       fields: []
     }
     

--- a/src/core/__tests__/FormatManager.spec.ts
+++ b/src/core/__tests__/FormatManager.spec.ts
@@ -1,0 +1,82 @@
+import { describe, expect, it, beforeEach } from 'vitest'
+import { FormatManager } from '../FormatManager'
+import type { BranchFormatTemplate } from '../FormatTypes'
+
+describe('FormatManager', () => {
+  beforeEach(() => {
+    localStorage.clear()
+  })
+
+  it('returns default formats initially', () => {
+    const formats = FormatManager.getFormats()
+    expect(formats.length).toBeGreaterThan(0)
+    expect(formats.some(f => f.id === 'gitflow')).toBe(true)
+    expect(formats.some(f => f.id === 'conventional-commits')).toBe(true)
+  })
+
+  it('can clone a predefined format into a custom one', () => {
+    const cloned = FormatManager.cloneFormat('gitflow', (val) => val + ' (translated)', '(copy)')
+    expect(cloned).not.toBeNull()
+    expect(cloned!.id.startsWith('custom-')).toBe(true)
+    expect(cloned!.isReadonly).toBe(false)
+    expect(cloned!.name).toContain('(copy)')
+    
+    // Ensure it's in the list of formats now
+    const customFormats = FormatManager.getCustomFormats()
+    expect(customFormats.length).toBe(1)
+    expect(customFormats[0].id).toBe(cloned!.id)
+  })
+
+  it('preserves field type and options when cloning', () => {
+    const cloned = FormatManager.cloneFormat('gitflow', (val) => val, '(copy)')
+    const typeField = cloned!.fields.find(f => f.id === 'type')
+    expect(typeField).toBeDefined()
+    expect(typeField!.type).toBe('select')
+    expect(typeField!.options).toBeDefined()
+    expect(typeField!.options!.length).toBeGreaterThan(0)
+    expect(typeField!.options).toContain('feature')
+  })
+
+  it('can add a new custom format and update it', () => {
+    const newFormat: BranchFormatTemplate = {
+      id: 'test-custom',
+      name: 'My Custom Format',
+      templateString: '{customField}',
+      isReadonly: false,
+      isVisible: true,
+      fields: [
+        { id: 'customField', label: 'Custom Field', type: 'select', options: ['A', 'B'], operations: [] }
+      ]
+    }
+    
+    FormatManager.addFormat(newFormat)
+    
+    let customFormats = FormatManager.getCustomFormats()
+    expect(customFormats.length).toBe(1)
+    expect(customFormats[0].fields[0].options).toEqual(['A', 'B'])
+
+    // Update the format
+    newFormat.fields[0].options = ['C', 'D']
+    FormatManager.updateFormat(newFormat)
+
+    customFormats = FormatManager.getCustomFormats()
+    expect(customFormats[0].fields[0].options).toEqual(['C', 'D'])
+  })
+
+  it('can delete a custom format', () => {
+    const newFormat: BranchFormatTemplate = {
+      id: 'test-custom-2',
+      name: 'Format to delete',
+      templateString: '',
+      isReadonly: false,
+      isVisible: true,
+      fields: []
+    }
+    
+    FormatManager.addFormat(newFormat)
+    expect(FormatManager.getCustomFormats().length).toBe(1)
+
+    FormatManager.deleteFormat('test-custom-2')
+    expect(FormatManager.getCustomFormats().length).toBe(0)
+  })
+})

--- a/src/i18n/de.json
+++ b/src/i18n/de.json
@@ -8,13 +8,11 @@
       "serverless": "Keine Registrierung"
     }
   },
+  "header": {
+    "config": "Einstellungen"
+  },
   "form": {
-    "projectId": "Projekt-ID",
-    "projectIdPlaceholder": "z. B. WEB",
-    "ticketId": "Ticket-ID",
-    "ticketIdPlaceholder": "z. B. 1234",
-    "developName": "Entwicklungsname",
-    "developNamePlaceholder": "z. B. add-login-form",
+    "formatLabel": "Format",
     "generate": "Branch-Namen Generieren"
   },
   "result": {
@@ -25,7 +23,9 @@
   "history": {
     "show": "Verlauf Anzeigen",
     "hide": "Verlauf Ausblenden",
-    "title": "Verlauf"
+    "title": "Verlauf",
+    "copy": "Kopieren",
+    "delete": "Löschen"
   },
   "cookies": {
     "text": "Helfen Sie uns, uns zu verbessern? Wir verwenden anonyme Analyse-Cookies, um die Nutzung zu verstehen und die Website zu optimieren.",
@@ -36,5 +36,86 @@
     "privacy": "Local-First-Entwicklung. Ihre Daten, Ihre Kontrolle.",
     "sourceCode": "Quellcode Anzeigen",
     "license": "Alle Rechte Vorbehalten"
+  },
+  "common": {
+    "cancel": "Abbrechen",
+    "confirm": "Bestätigen"
+  },
+  "preview": {
+    "title": "Vorschau",
+    "placeholder": "Wählen Sie ein Format"
+  },
+  "configurator": {
+    "availableFormats": "Verfügbare Formate",
+    "createFormat": "Format Erstellen",
+    "badgeBuiltin": "Integriert",
+    "badgeSelected": "Ausgewählt",
+    "badgeHidden": "Ausgeblendet",
+    "edit": "Bearbeiten",
+    "clone": "Klonen",
+    "delete": "Löschen",
+    "exportCustom": "Eigene Formate Exportieren",
+    "importJson": "JSON Importieren",
+    "back": "Zurück",
+    "exportEmpty": "Es gibt keine eigenen Formate zum Exportieren.",
+    "importSuccess": "Formate erfolgreich importiert.",
+    "importError": "Fehler beim Importieren. Ungültige Datei.",
+    "newFormatName": "Neues Format",
+    "newFieldLabel": "Neues Feld",
+    "deleteModal": {
+      "title": "Format Löschen",
+      "message": "Möchten Sie dieses eigene Format wirklich löschen? Diese Aktion kann nicht rückgängig gemacht werden."
+    },
+    "editor": {
+      "on": "Aktiviert",
+      "off": "Deaktiviert",
+      "visibleHintOn": "Dieses Format erscheint als Option im Hauptformular.",
+      "visibleHintOff": "Dieses Format ist ausgeblendet und erscheint nicht als Option im Hauptformular.",
+      "readonlyHint": "Dieses Format ist in der App enthalten: Sie können nur die Sichtbarkeit und die Sprache ändern. Um Felder oder Vorlage zu bearbeiten, klonen Sie es aus der Liste und bearbeiten Sie die Kopie.",
+      "formatName": "Formatname",
+      "template": "Vorlage (verwenden Sie {id}, um Felder einzufügen)",
+      "language": "Sprache (Zeichenbereinigung: ñ, /, Akzente...)",
+      "fields": "Felder",
+      "field": "Feld {n}",
+      "deleteField": "Feld löschen",
+      "fieldId": "Feld-ID",
+      "fieldIdPlaceholder": "z. B. ticketId",
+      "fieldLabel": "Feldname",
+      "fieldLabelPlaceholder": "z. B. Ticket-ID",
+      "type": "Typ",
+      "typeText": "Freitext",
+      "typeSelect": "Auswahl",
+      "capitalization": "Groß-/Kleinschreibung",
+      "capUpper": "Großbuchstaben",
+      "capLower": "Kleinbuchstaben",
+      "capAsIs": "Unverändert",
+      "options": "Optionen (durch Kommas getrennt)",
+      "optionsPlaceholder": "z. B. feature, fix, hotfix",
+      "addField": "+ Feld Hinzufügen",
+      "cancel": "Abbrechen",
+      "save": "Speichern",
+      "close": "Schließen"
+    },
+    "cloneSuffix": "(Kopie)"
+  },
+  "formats": {
+    "defaultApp": {
+      "name": "Standardformat (App)",
+      "projectId": "Projekt-ID",
+      "ticketId": "Ticket-ID",
+      "featureName": "Funktionsname"
+    },
+    "gitflow": {
+      "name": "GitFlow (type/ticket-desc)",
+      "type": "Typ",
+      "ticketId": "Ticket-ID",
+      "description": "Beschreibung"
+    },
+    "conventionalCommits": {
+      "name": "Conventional Commits",
+      "type": "Typ (feat, fix...)",
+      "scope": "Geltungsbereich",
+      "description": "Beschreibung"
+    }
   }
 }

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -8,13 +8,11 @@
       "serverless": "No Registration"
     }
   },
+  "header": {
+    "config": "Settings"
+  },
   "form": {
-    "projectId": "Project ID",
-    "projectIdPlaceholder": "e.g. WEB",
-    "ticketId": "Ticket ID",
-    "ticketIdPlaceholder": "e.g. 1234",
-    "developName": "Develop Name",
-    "developNamePlaceholder": "e.g. add-login-form",
+    "formatLabel": "Format",
     "generate": "Generate Branch Name"
   },
   "result": {
@@ -25,7 +23,9 @@
   "history": {
     "show": "Show History",
     "hide": "Hide History",
-    "title": "History"
+    "title": "History",
+    "copy": "Copy",
+    "delete": "Delete"
   },
   "cookies": {
     "text": "Help us improve? We use anonymous analytics cookies to understand usage and optimize the web.",
@@ -36,5 +36,86 @@
     "privacy": "Local-first development. Your data, your control.",
     "sourceCode": "View Source Code",
     "license": "All Rights Reserved"
+  },
+  "common": {
+    "cancel": "Cancel",
+    "confirm": "Confirm"
+  },
+  "preview": {
+    "title": "Preview",
+    "placeholder": "Select a format"
+  },
+  "configurator": {
+    "availableFormats": "Available Formats",
+    "createFormat": "Create Format",
+    "badgeBuiltin": "Built-in",
+    "badgeSelected": "Selected",
+    "badgeHidden": "Hidden",
+    "edit": "Edit",
+    "clone": "Clone",
+    "delete": "Delete",
+    "exportCustom": "Export Custom Formats",
+    "importJson": "Import JSON",
+    "back": "Back",
+    "exportEmpty": "There are no custom formats to export.",
+    "importSuccess": "Formats imported successfully.",
+    "importError": "Error importing formats. Invalid file.",
+    "newFormatName": "New Format",
+    "newFieldLabel": "New Field",
+    "deleteModal": {
+      "title": "Delete Format",
+      "message": "Are you sure you want to delete this custom format? This action cannot be undone."
+    },
+    "editor": {
+      "on": "On",
+      "off": "Off",
+      "visibleHintOn": "This format appears as an option in the main form.",
+      "visibleHintOff": "This format is hidden: it won't appear as an option in the main form.",
+      "readonlyHint": "This format ships with the app: you can only change whether it is visible and its language. To edit its fields or template, clone it from the list and edit the copy.",
+      "formatName": "Format name",
+      "template": "Template (use {id} to inject fields)",
+      "language": "Language (character sanitization: ñ, /, accents...)",
+      "fields": "Fields",
+      "field": "Field {n}",
+      "deleteField": "Delete field",
+      "fieldId": "Field ID",
+      "fieldIdPlaceholder": "e.g. ticketId",
+      "fieldLabel": "Field Name",
+      "fieldLabelPlaceholder": "e.g. Ticket ID",
+      "type": "Type",
+      "typeText": "Free Text",
+      "typeSelect": "Select",
+      "capitalization": "Capitalization",
+      "capUpper": "Uppercase",
+      "capLower": "Lowercase",
+      "capAsIs": "As is",
+      "options": "Options (comma-separated)",
+      "optionsPlaceholder": "e.g. feature, fix, hotfix",
+      "addField": "+ Add Field",
+      "cancel": "Cancel",
+      "save": "Save",
+      "close": "Close"
+    },
+    "cloneSuffix": "(Clone)"
+  },
+  "formats": {
+    "defaultApp": {
+      "name": "Default Format (App)",
+      "projectId": "Project ID",
+      "ticketId": "Ticket ID",
+      "featureName": "Feature Name"
+    },
+    "gitflow": {
+      "name": "GitFlow (type/ticket-desc)",
+      "type": "Type",
+      "ticketId": "Ticket ID",
+      "description": "Description"
+    },
+    "conventionalCommits": {
+      "name": "Conventional Commits",
+      "type": "Type (feat, fix...)",
+      "scope": "Scope",
+      "description": "Description"
+    }
   }
 }

--- a/src/i18n/es.json
+++ b/src/i18n/es.json
@@ -8,13 +8,11 @@
       "serverless": "Sin Registro"
     }
   },
+  "header": {
+    "config": "Configuración"
+  },
   "form": {
-    "projectId": "ID del Proyecto",
-    "projectIdPlaceholder": "ej. WEB",
-    "ticketId": "ID del Ticket",
-    "ticketIdPlaceholder": "ej. 1234",
-    "developName": "Nombre de Desarrollo",
-    "developNamePlaceholder": "ej. add-login-form",
+    "formatLabel": "Formato",
     "generate": "Generar Nombre de Rama"
   },
   "result": {
@@ -25,7 +23,9 @@
   "history": {
     "show": "Mostrar Historial",
     "hide": "Ocultar Historial",
-    "title": "Historial"
+    "title": "Historial",
+    "copy": "Copiar",
+    "delete": "Borrar"
   },
   "cookies": {
     "text": "¿Nos ayudas a mejorar? Usamos cookies de análisis anónimas para comprender el uso y optimizar la web.",
@@ -36,5 +36,86 @@
     "privacy": "Desarrollo local-first. Tus datos, tu control.",
     "sourceCode": "Ver Código Fuente",
     "license": "Derechos Reservados"
+  },
+  "common": {
+    "cancel": "Cancelar",
+    "confirm": "Confirmar"
+  },
+  "preview": {
+    "title": "Previsualización",
+    "placeholder": "Selecciona un formato"
+  },
+  "configurator": {
+    "availableFormats": "Formatos Disponibles",
+    "createFormat": "Crear Formato",
+    "badgeBuiltin": "Predeterminado",
+    "badgeSelected": "Seleccionado",
+    "badgeHidden": "Oculto",
+    "edit": "Editar",
+    "clone": "Clonar",
+    "delete": "Borrar",
+    "exportCustom": "Exportar Personalizados",
+    "importJson": "Importar JSON",
+    "back": "Volver",
+    "exportEmpty": "No hay formatos personalizados para exportar.",
+    "importSuccess": "Formatos importados correctamente.",
+    "importError": "Error al importar formatos. Archivo inválido.",
+    "newFormatName": "Nuevo Formato",
+    "newFieldLabel": "Nuevo Campo",
+    "deleteModal": {
+      "title": "Eliminar Formato",
+      "message": "¿Estás seguro de que quieres eliminar este formato personalizado? Esta acción no se puede deshacer."
+    },
+    "editor": {
+      "on": "Activado",
+      "off": "Desactivado",
+      "visibleHintOn": "Este formato aparece como opción en el formulario principal.",
+      "visibleHintOff": "Este formato está oculto: no aparecerá como opción en el formulario principal.",
+      "readonlyHint": "Este formato viene incluido en la app: solo puedes cambiar si está visible y su idioma. Para editar sus campos o plantilla, clónalo desde la lista y edita la copia.",
+      "formatName": "Nombre del formato",
+      "template": "Plantilla (Usa {id} para inyectar campos)",
+      "language": "Idioma (saneado de caracteres: ñ, /, tildes...)",
+      "fields": "Campos",
+      "field": "Campo {n}",
+      "deleteField": "Eliminar campo",
+      "fieldId": "ID del Campo",
+      "fieldIdPlaceholder": "ej: ticketId",
+      "fieldLabel": "Nombre del Campo",
+      "fieldLabelPlaceholder": "ej: ID Ticket",
+      "type": "Tipo",
+      "typeText": "Texto Libre",
+      "typeSelect": "Selector",
+      "capitalization": "Capitalización",
+      "capUpper": "Mayúsculas",
+      "capLower": "Minúsculas",
+      "capAsIs": "Tal cual",
+      "options": "Opciones (separadas por comas)",
+      "optionsPlaceholder": "ej: feature, fix, hotfix",
+      "addField": "+ Añadir Campo",
+      "cancel": "Cancelar",
+      "save": "Guardar",
+      "close": "Cerrar"
+    },
+    "cloneSuffix": "(Clon)"
+  },
+  "formats": {
+    "defaultApp": {
+      "name": "Formato por defecto (App)",
+      "projectId": "ID Proyecto",
+      "ticketId": "ID Ticket",
+      "featureName": "Nombre Funcionalidad"
+    },
+    "gitflow": {
+      "name": "GitFlow (type/ticket-desc)",
+      "type": "Tipo",
+      "ticketId": "ID Ticket",
+      "description": "Descripción"
+    },
+    "conventionalCommits": {
+      "name": "Conventional Commits",
+      "type": "Tipo (feat, fix...)",
+      "scope": "Ámbito",
+      "description": "Descripción"
+    }
   }
 }

--- a/src/i18n/fr.json
+++ b/src/i18n/fr.json
@@ -8,13 +8,11 @@
       "serverless": "Sans Inscription"
     }
   },
+  "header": {
+    "config": "Paramètres"
+  },
   "form": {
-    "projectId": "ID du Projet",
-    "projectIdPlaceholder": "ex. WEB",
-    "ticketId": "ID du Ticket",
-    "ticketIdPlaceholder": "ex. 1234",
-    "developName": "Nom de Développement",
-    "developNamePlaceholder": "ex. add-login-form",
+    "formatLabel": "Format",
     "generate": "Générer le Nom de Branche"
   },
   "result": {
@@ -25,7 +23,9 @@
   "history": {
     "show": "Afficher l'Historique",
     "hide": "Masquer l'Historique",
-    "title": "Historique"
+    "title": "Historique",
+    "copy": "Copier",
+    "delete": "Supprimer"
   },
   "cookies": {
     "text": "Nous aider à nous améliorer ? Nous utilisons des cookies d'analyse anonymes pour comprendre l'utilisation et optimiser le site.",
@@ -36,5 +36,86 @@
     "privacy": "Développement local-first. Vos données, votre contrôle.",
     "sourceCode": "Voir le Code Source",
     "license": "Tous Droits Réservés"
+  },
+  "common": {
+    "cancel": "Annuler",
+    "confirm": "Confirmer"
+  },
+  "preview": {
+    "title": "Aperçu",
+    "placeholder": "Sélectionnez un format"
+  },
+  "configurator": {
+    "availableFormats": "Formats Disponibles",
+    "createFormat": "Créer un Format",
+    "badgeBuiltin": "Intégré",
+    "badgeSelected": "Sélectionné",
+    "badgeHidden": "Masqué",
+    "edit": "Modifier",
+    "clone": "Cloner",
+    "delete": "Supprimer",
+    "exportCustom": "Exporter les Formats Personnalisés",
+    "importJson": "Importer un JSON",
+    "back": "Retour",
+    "exportEmpty": "Aucun format personnalisé à exporter.",
+    "importSuccess": "Formats importés avec succès.",
+    "importError": "Erreur lors de l'importation. Fichier invalide.",
+    "newFormatName": "Nouveau Format",
+    "newFieldLabel": "Nouveau Champ",
+    "deleteModal": {
+      "title": "Supprimer le Format",
+      "message": "Êtes-vous sûr de vouloir supprimer ce format personnalisé ? Cette action est irréversible."
+    },
+    "editor": {
+      "on": "Activé",
+      "off": "Désactivé",
+      "visibleHintOn": "Ce format apparaît comme option dans le formulaire principal.",
+      "visibleHintOff": "Ce format est masqué : il n'apparaîtra pas comme option dans le formulaire principal.",
+      "readonlyHint": "Ce format est fourni avec l'application : vous ne pouvez modifier que sa visibilité et sa langue. Pour modifier ses champs ou son modèle, clonez-le depuis la liste et modifiez la copie.",
+      "formatName": "Nom du format",
+      "template": "Modèle (utilisez {id} pour insérer des champs)",
+      "language": "Langue (nettoyage des caractères : ñ, /, accents...)",
+      "fields": "Champs",
+      "field": "Champ {n}",
+      "deleteField": "Supprimer le champ",
+      "fieldId": "ID du Champ",
+      "fieldIdPlaceholder": "ex. ticketId",
+      "fieldLabel": "Nom du Champ",
+      "fieldLabelPlaceholder": "ex. ID du Ticket",
+      "type": "Type",
+      "typeText": "Texte Libre",
+      "typeSelect": "Sélecteur",
+      "capitalization": "Casse",
+      "capUpper": "Majuscules",
+      "capLower": "Minuscules",
+      "capAsIs": "Telle quelle",
+      "options": "Options (séparées par des virgules)",
+      "optionsPlaceholder": "ex. feature, fix, hotfix",
+      "addField": "+ Ajouter un Champ",
+      "cancel": "Annuler",
+      "save": "Enregistrer",
+      "close": "Fermer"
+    },
+    "cloneSuffix": "(Clone)"
+  },
+  "formats": {
+    "defaultApp": {
+      "name": "Format par défaut (App)",
+      "projectId": "ID du Projet",
+      "ticketId": "ID du Ticket",
+      "featureName": "Nom de la Fonctionnalité"
+    },
+    "gitflow": {
+      "name": "GitFlow (type/ticket-desc)",
+      "type": "Type",
+      "ticketId": "ID du Ticket",
+      "description": "Description"
+    },
+    "conventionalCommits": {
+      "name": "Conventional Commits",
+      "type": "Type (feat, fix...)",
+      "scope": "Portée",
+      "description": "Description"
+    }
   }
 }

--- a/src/i18n/it.json
+++ b/src/i18n/it.json
@@ -8,13 +8,11 @@
       "serverless": "Senza Registrazione"
     }
   },
+  "header": {
+    "config": "Impostazioni"
+  },
   "form": {
-    "projectId": "ID Progetto",
-    "projectIdPlaceholder": "es. WEB",
-    "ticketId": "ID Ticket",
-    "ticketIdPlaceholder": "es. 1234",
-    "developName": "Nome Sviluppo",
-    "developNamePlaceholder": "es. add-login-form",
+    "formatLabel": "Formato",
     "generate": "Genera Nome Branch"
   },
   "result": {
@@ -25,7 +23,9 @@
   "history": {
     "show": "Mostra Cronologia",
     "hide": "Nascondi Cronologia",
-    "title": "Cronologia"
+    "title": "Cronologia",
+    "copy": "Copia",
+    "delete": "Elimina"
   },
   "cookies": {
     "text": "Aiutaci a migliorare? Utilizziamo cookie di analisi anonimi per comprendere l'uso e ottimizzare il sito.",
@@ -36,5 +36,86 @@
     "privacy": "Sviluppo local-first. I tuoi dati, il tuo controllo.",
     "sourceCode": "Visualizza Codice Sorgente",
     "license": "Tutti i Diritti Riservati"
+  },
+  "common": {
+    "cancel": "Annulla",
+    "confirm": "Conferma"
+  },
+  "preview": {
+    "title": "Anteprima",
+    "placeholder": "Seleziona un formato"
+  },
+  "configurator": {
+    "availableFormats": "Formati Disponibili",
+    "createFormat": "Crea Formato",
+    "badgeBuiltin": "Predefinito",
+    "badgeSelected": "Selezionato",
+    "badgeHidden": "Nascosto",
+    "edit": "Modifica",
+    "clone": "Clona",
+    "delete": "Elimina",
+    "exportCustom": "Esporta Formati Personalizzati",
+    "importJson": "Importa JSON",
+    "back": "Indietro",
+    "exportEmpty": "Non ci sono formati personalizzati da esportare.",
+    "importSuccess": "Formati importati correttamente.",
+    "importError": "Errore durante l'importazione. File non valido.",
+    "newFormatName": "Nuovo Formato",
+    "newFieldLabel": "Nuovo Campo",
+    "deleteModal": {
+      "title": "Elimina Formato",
+      "message": "Sei sicuro di voler eliminare questo formato personalizzato? Questa azione non può essere annullata."
+    },
+    "editor": {
+      "on": "Attivo",
+      "off": "Disattivo",
+      "visibleHintOn": "Questo formato appare come opzione nel modulo principale.",
+      "visibleHintOff": "Questo formato è nascosto: non apparirà come opzione nel modulo principale.",
+      "readonlyHint": "Questo formato è incluso nell'app: puoi modificare solo se è visibile e la sua lingua. Per modificare campi o modello, clonalo dall'elenco e modifica la copia.",
+      "formatName": "Nome del formato",
+      "template": "Modello (usa {id} per inserire i campi)",
+      "language": "Lingua (pulizia caratteri: ñ, /, accenti...)",
+      "fields": "Campi",
+      "field": "Campo {n}",
+      "deleteField": "Elimina campo",
+      "fieldId": "ID del Campo",
+      "fieldIdPlaceholder": "es. ticketId",
+      "fieldLabel": "Nome del Campo",
+      "fieldLabelPlaceholder": "es. ID Ticket",
+      "type": "Tipo",
+      "typeText": "Testo Libero",
+      "typeSelect": "Selettore",
+      "capitalization": "Maiuscole/Minuscole",
+      "capUpper": "Maiuscolo",
+      "capLower": "Minuscolo",
+      "capAsIs": "Invariato",
+      "options": "Opzioni (separate da virgole)",
+      "optionsPlaceholder": "es. feature, fix, hotfix",
+      "addField": "+ Aggiungi Campo",
+      "cancel": "Annulla",
+      "save": "Salva",
+      "close": "Chiudi"
+    },
+    "cloneSuffix": "(Clone)"
+  },
+  "formats": {
+    "defaultApp": {
+      "name": "Formato predefinito (App)",
+      "projectId": "ID Progetto",
+      "ticketId": "ID Ticket",
+      "featureName": "Nome Funzionalità"
+    },
+    "gitflow": {
+      "name": "GitFlow (type/ticket-desc)",
+      "type": "Tipo",
+      "ticketId": "ID Ticket",
+      "description": "Descrizione"
+    },
+    "conventionalCommits": {
+      "name": "Conventional Commits",
+      "type": "Tipo (feat, fix...)",
+      "scope": "Ambito",
+      "description": "Descrizione"
+    }
   }
 }

--- a/src/i18n/pt.json
+++ b/src/i18n/pt.json
@@ -8,13 +8,11 @@
       "serverless": "Sem Registo"
     }
   },
+  "header": {
+    "config": "Definições"
+  },
   "form": {
-    "projectId": "ID do Projeto",
-    "projectIdPlaceholder": "ex. WEB",
-    "ticketId": "ID do Ticket",
-    "ticketIdPlaceholder": "ex. 1234",
-    "developName": "Nome de Desenvolvimento",
-    "developNamePlaceholder": "ex. add-login-form",
+    "formatLabel": "Formato",
     "generate": "Gerar Nome de Branch"
   },
   "result": {
@@ -25,7 +23,9 @@
   "history": {
     "show": "Mostrar Histórico",
     "hide": "Ocultar Histórico",
-    "title": "Histórico"
+    "title": "Histórico",
+    "copy": "Copiar",
+    "delete": "Eliminar"
   },
   "cookies": {
     "text": "Ajuda-nos a melhorar? Usamos cookies de análise anónimos para compreender o uso e otimizar a web.",
@@ -36,5 +36,86 @@
     "privacy": "Desenvolvimento local-first. Seus dados, seu controlo.",
     "sourceCode": "Ver Código Fonte",
     "license": "Todos os Direitos Reservados"
+  },
+  "common": {
+    "cancel": "Cancelar",
+    "confirm": "Confirmar"
+  },
+  "preview": {
+    "title": "Pré-visualização",
+    "placeholder": "Selecione um formato"
+  },
+  "configurator": {
+    "availableFormats": "Formatos Disponíveis",
+    "createFormat": "Criar Formato",
+    "badgeBuiltin": "Predefinido",
+    "badgeSelected": "Selecionado",
+    "badgeHidden": "Oculto",
+    "edit": "Editar",
+    "clone": "Clonar",
+    "delete": "Eliminar",
+    "exportCustom": "Exportar Formatos Personalizados",
+    "importJson": "Importar JSON",
+    "back": "Voltar",
+    "exportEmpty": "Não há formatos personalizados para exportar.",
+    "importSuccess": "Formatos importados com sucesso.",
+    "importError": "Erro ao importar formatos. Ficheiro inválido.",
+    "newFormatName": "Novo Formato",
+    "newFieldLabel": "Novo Campo",
+    "deleteModal": {
+      "title": "Eliminar Formato",
+      "message": "Tem a certeza de que deseja eliminar este formato personalizado? Esta ação não pode ser desfeita."
+    },
+    "editor": {
+      "on": "Ativado",
+      "off": "Desativado",
+      "visibleHintOn": "Este formato aparece como opção no formulário principal.",
+      "visibleHintOff": "Este formato está oculto: não aparecerá como opção no formulário principal.",
+      "readonlyHint": "Este formato vem incluído na aplicação: só podes alterar se está visível e o seu idioma. Para editar os campos ou o modelo, clona-o a partir da lista e edita a cópia.",
+      "formatName": "Nome do formato",
+      "template": "Modelo (usa {id} para inserir campos)",
+      "language": "Idioma (limpeza de caracteres: ñ, /, acentos...)",
+      "fields": "Campos",
+      "field": "Campo {n}",
+      "deleteField": "Eliminar campo",
+      "fieldId": "ID do Campo",
+      "fieldIdPlaceholder": "ex. ticketId",
+      "fieldLabel": "Nome do Campo",
+      "fieldLabelPlaceholder": "ex. ID do Ticket",
+      "type": "Tipo",
+      "typeText": "Texto Livre",
+      "typeSelect": "Seletor",
+      "capitalization": "Capitalização",
+      "capUpper": "Maiúsculas",
+      "capLower": "Minúsculas",
+      "capAsIs": "Tal como está",
+      "options": "Opções (separadas por vírgulas)",
+      "optionsPlaceholder": "ex. feature, fix, hotfix",
+      "addField": "+ Adicionar Campo",
+      "cancel": "Cancelar",
+      "save": "Guardar",
+      "close": "Fechar"
+    },
+    "cloneSuffix": "(Cópia)"
+  },
+  "formats": {
+    "defaultApp": {
+      "name": "Formato por defeito (App)",
+      "projectId": "ID do Projeto",
+      "ticketId": "ID do Ticket",
+      "featureName": "Nome da Funcionalidade"
+    },
+    "gitflow": {
+      "name": "GitFlow (type/ticket-desc)",
+      "type": "Tipo",
+      "ticketId": "ID do Ticket",
+      "description": "Descrição"
+    },
+    "conventionalCommits": {
+      "name": "Conventional Commits",
+      "type": "Tipo (feat, fix...)",
+      "scope": "Âmbito",
+      "description": "Descrição"
+    }
   }
 }

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,10 +1,16 @@
 import { fileURLToPath, URL } from 'node:url'
+import { readFileSync } from 'node:fs'
 import { defineConfig } from 'vite'
 import vue from '@vitejs/plugin-vue'
+
+const pkg = JSON.parse(readFileSync(new URL('./package.json', import.meta.url), 'utf-8'))
 
 export default defineConfig({
   //base: '/web-branch-name-formatter/',
   plugins: [vue()],
+  define: {
+    __APP_VERSION__: JSON.stringify(pkg.version)
+  },
   resolve: {
     alias: {
       '@': fileURLToPath(new URL('./src', import.meta.url))
@@ -12,8 +18,8 @@ export default defineConfig({
   },
   css: {
     preprocessorOptions: {
-      sass: {
-        additionalData: `@import "@/assets/variables.scss"`
+      scss: {
+        additionalData: `@use "@/assets/variables.scss" as vars;`
       }
     }
   }


### PR DESCRIPTION
This pull request marks the first stable (1.0.0) release of the Branch Name Formatter app. It introduces a comprehensive redesign of the app’s visual layer, a rework of the branch format system, and significant improvements to documentation and internationalization. The changes modernize the user experience, clarify the project’s structure, and ensure all notable updates are tracked for future reference.

**Highlights of the release:**
- Full UI and UX redesign, including responsive layouts and new reusable components.
- Dynamic, language-aware branch format system with live preview and per-field capitalization.
- Complete i18n coverage for six languages, including the configuration screens.
- Addition of a detailed changelog and improved project documentation in both English and Spanish.

The most important changes are:

### Documentation & Changelog
- Added a comprehensive `CHANGELOG.md` documenting all notable changes, following Keep a Changelog and Semantic Versioning conventions.
- Updated both `README.md` and `README-es.md` to reflect the new dynamic format system, language-aware sanitization, expanded multi-language support, and improved project architecture explanations. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L1-R40) [[2]](diffhunk://#diff-b4ec24a264360b57fac58c7c0e3df67ea606364695c435adf14779e6f91fd6d0L1-R40)
- Expanded and clarified the architecture documentation in both English (`docs/ARCHITECTURE.md`) and Spanish (`docs/ARCHITECTURE_ES.md`), detailing the new logic and UI layers, localization approach, and privacy/data handling. [[1]](diffhunk://#diff-ff21b6b9a3a33e9d9056ac96882cc348d7077612b5931068f7459707b21eb3d1L5-R31) [[2]](diffhunk://#diff-6f0d2a0cdec963f053a5d57c75a28dcc0eff00fbd321ff5bb8eadfe2cb8921ccL5-R31)

### Feature and UI Overhaul
- Overhauled the main app UI: replaced the original header and form logic with a new `AppHeader` component, separated the main view and configuration view, and introduced toggling between them. [[1]](diffhunk://#diff-7a7a37b12ee1265d7e27577ec286120d2cbc0940908635e264a2be44ccb9a8a0L1-R11) [[2]](diffhunk://#diff-7a7a37b12ee1265d7e27577ec286120d2cbc0940908635e264a2be44ccb9a8a0L25-R41)

### Versioning
- Updated the app version to `1.0.0` in `package.json` to mark the first stable release.