### PR TITLE
Persist UI language in localStorage and add config export/import

### DIFF
--- a/src/components/AppConfigurationView.vue
+++ b/src/components/AppConfigurationView.vue
@@ -141,11 +141,7 @@ const updatePreview = (format: BranchFormatTemplate) => {
 
 // Import/Export
 const handleExport = () => {
-  const dataStr = FormatManager.exportCustomFormats()
-  if (dataStr === '[]') {
-    alert(t('configurator.exportEmpty'))
-    return
-  }
+  const dataStr = FormatManager.exportConfiguration()
   const dataUri = 'data:application/json;charset=utf-8,'+ encodeURIComponent(dataStr)
   const exportFileDefaultName = 'branch-formats.json'
   const linkElement = document.createElement('a')

--- a/src/components/AppHeader.vue
+++ b/src/components/AppHeader.vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
 import LangSelector from '@/components/LangSelector.vue'
 import SettingsIcon from '@/components/SettingsIcon.vue'
+import { setUiLanguage, type SupportedLocale } from '@/i18n'
 
 const props = defineProps<{
   showConfig: boolean;
@@ -11,6 +12,10 @@ const emit = defineEmits<{
   (e: 'toggleConfig'): void;
   (e: 'home'): void;
 }>();
+
+const handleLanguageChange = (langCode: string) => {
+  setUiLanguage(langCode as SupportedLocale)
+}
 </script>
 
 <template>
@@ -23,7 +28,7 @@ const emit = defineEmits<{
       <div class="navbar-actions">
         <LangSelector
           :modelValue="$i18n.locale"
-          @update:modelValue="$i18n.locale = $event"
+          @update:modelValue="handleLanguageChange"
           :options="languages"
         />
 

--- a/src/components/BranchList.vue
+++ b/src/components/BranchList.vue
@@ -30,13 +30,8 @@ const handleDeleteBranch = (branchId: number) => {
   display: flex;
   flex-direction: column;
   gap: 0.75rem;
-}
-
-@media (min-width: vars.$bp-tablet) {
-  .branch_list {
-    display: grid;
-    grid-template-columns: repeat(auto-fill, minmax(320px, 1fr));
-    gap: 0.75rem;
-  }
+  width: 100%;
+  max-width: 600px;
+  margin: 0 auto;
 }
 </style>

--- a/src/core/FormatManager.ts
+++ b/src/core/FormatManager.ts
@@ -1,4 +1,5 @@
 import type { BranchFormatTemplate, LanguageProfile } from '@/core/FormatTypes'
+import { getUiLanguage, setUiLanguage, type SupportedLocale } from '@/i18n'
 
 export class FormatManager {
   private static readonly STORAGE_KEY_CUSTOM = 'branch-formats-custom'
@@ -161,27 +162,83 @@ export class FormatManager {
     return clonedFormat
   }
 
+  static exportConfiguration(): string {
+    const config = {
+      version: 1,
+      uiLanguage: getUiLanguage(),
+      defaultFormatId: this.getDefaultFormatId(),
+      formats: this.getFormats()
+    }
+    return JSON.stringify(config, null, 2)
+  }
+
   static exportCustomFormats(): string {
-    return JSON.stringify(this.getCustomFormats(), null, 2)
+    return this.exportConfiguration()
   }
 
   static importCustomFormats(jsonString: string): void {
     try {
-      const parsed = JSON.parse(jsonString) as BranchFormatTemplate[]
-      if (!Array.isArray(parsed)) throw new Error('Invalid format')
+      const parsed = JSON.parse(jsonString)
 
-      const currentCustom = this.getCustomFormats()
-      // Create new IDs for imported to avoid collisions, or just append them if they look valid
-      const newFormats = parsed.map(f => ({
-        ...f,
-        id: `imported-${Date.now()}-${Math.random().toString(36).substring(2, 9)}`,
-        isReadonly: false
-      }))
+      if (Array.isArray(parsed)) {
+        this.importFormatsArray(parsed as BranchFormatTemplate[])
+        return
+      }
 
-      this.saveCustomFormats([...currentCustom, ...newFormats])
+      if (typeof parsed === 'object' && parsed !== null) {
+        if (parsed.uiLanguage && typeof parsed.uiLanguage === 'string') {
+          setUiLanguage(parsed.uiLanguage as SupportedLocale)
+        }
+
+        if (parsed.defaultFormatId && typeof parsed.defaultFormatId === 'string') {
+          this.setDefaultFormatId(parsed.defaultFormatId)
+        }
+
+        if (parsed.predefinedLanguageOverrides && typeof parsed.predefinedLanguageOverrides === 'object') {
+          const currentOverrides = this.getPredefinedLanguageOverrides()
+          const newOverrides = { ...currentOverrides, ...parsed.predefinedLanguageOverrides }
+          this.savePredefinedLanguageOverrides(newOverrides)
+        }
+
+        const formatsArray = Array.isArray(parsed.formats)
+          ? parsed.formats
+          : (Array.isArray(parsed.customFormats) ? parsed.customFormats : [])
+
+        if (formatsArray.length > 0) {
+          this.importFormatsArray(formatsArray, true)
+        }
+      } else {
+        throw new Error('Invalid format structure')
+      }
     } catch (e) {
       console.error('Error importing formats:', e)
       throw e
     }
+  }
+
+  private static importFormatsArray(formatsArray: BranchFormatTemplate[], processPredefined = true): void {
+    const customToSave: BranchFormatTemplate[] = [...this.getCustomFormats()]
+    const predefinedIds = this.DEFAULT_FORMATS.map(f => f.id)
+
+    for (const item of formatsArray) {
+      if (predefinedIds.includes(item.id)) {
+        if (processPredefined && item.language) {
+          this.setLanguage(item.id, item.language)
+        }
+      } else {
+        const existingIndex = customToSave.findIndex(c => c.id === item.id)
+        const formatItem: BranchFormatTemplate = {
+          ...item,
+          isReadonly: false
+        }
+        if (existingIndex !== -1) {
+          customToSave[existingIndex] = formatItem
+        } else {
+          customToSave.push(formatItem)
+        }
+      }
+    }
+
+    this.saveCustomFormats(customToSave)
   }
 }

--- a/src/core/__tests__/FormatManager.spec.ts
+++ b/src/core/__tests__/FormatManager.spec.ts
@@ -79,4 +79,54 @@ describe('FormatManager', () => {
     FormatManager.deleteFormat('test-custom-2')
     expect(FormatManager.getCustomFormats().length).toBe(0)
   })
+
+  it('exports full configuration clean object containing default format, uiLanguage and formats array', () => {
+    FormatManager.setDefaultFormatId('gitflow')
+    FormatManager.setLanguage('gitflow', 'en')
+    
+    const exportedStr = FormatManager.exportConfiguration()
+    const exportedObj = JSON.parse(exportedStr)
+
+    expect(exportedObj.defaultFormatId).toBe('gitflow')
+    expect(exportedObj.uiLanguage).toBeDefined()
+    expect(exportedObj.formats).toBeDefined()
+    expect(Array.isArray(exportedObj.formats)).toBe(true)
+    const gitflow = exportedObj.formats.find((f: any) => f.id === 'gitflow')
+    expect(gitflow.language).toBe('en')
+  })
+
+  it('imports full configuration correctly including uiLanguage', () => {
+    const configToImport = {
+      version: 1,
+      uiLanguage: 'de',
+      defaultFormatId: 'conventional-commits',
+      formats: [
+        {
+          id: 'gitflow',
+          name: 'formats.gitflow.name',
+          templateString: '{type}/{ticketId}-{description}',
+          isReadonly: true,
+          language: 'fr',
+          fields: []
+        },
+        {
+          id: 'imported-custom-1',
+          name: 'Imported Custom',
+          templateString: '{test}',
+          isReadonly: false,
+          language: 'es',
+          fields: []
+        }
+      ]
+    }
+
+    FormatManager.importCustomFormats(JSON.stringify(configToImport))
+
+    expect(FormatManager.getDefaultFormatId()).toBe('conventional-commits')
+    const formats = FormatManager.getFormats()
+    const gitflow = formats.find(f => f.id === 'gitflow')
+    expect(gitflow?.language).toBe('fr')
+    expect(FormatManager.getCustomFormats().length).toBe(1)
+    expect(FormatManager.getCustomFormats()[0].name).toBe('Imported Custom')
+  })
 })

--- a/src/i18n/index.ts
+++ b/src/i18n/index.ts
@@ -8,11 +8,25 @@ import pt from './pt.json'
 
 type MessageSchema = typeof en
 
-const supportedLocales = ['en', 'es', 'fr', 'de', 'it', 'pt'] as const
-type SupportedLocale = (typeof supportedLocales)[number]
+export const supportedLocales = ['en', 'es', 'fr', 'de', 'it', 'pt'] as const
+export type SupportedLocale = (typeof supportedLocales)[number]
 
-const browserLocale = navigator.language.split('-')[0] as SupportedLocale
-const initialLocale = supportedLocales.includes(browserLocale) ? browserLocale : 'en'
+const STORAGE_KEY_UI_LANG = 'app-ui-language'
+
+const getStoredLocale = (): SupportedLocale | null => {
+  try {
+    const saved = localStorage.getItem(STORAGE_KEY_UI_LANG)
+    if (saved && supportedLocales.includes(saved as SupportedLocale)) {
+      return saved as SupportedLocale
+    }
+  } catch {
+    // fallback if localStorage is not accessible
+  }
+  return null
+}
+
+const browserLocale = (typeof navigator !== 'undefined' ? navigator.language.split('-')[0] : 'en') as SupportedLocale
+const initialLocale = getStoredLocale() || (supportedLocales.includes(browserLocale) ? browserLocale : 'en')
 
 const i18n = createI18n<[MessageSchema], SupportedLocale>({
   legacy: false,
@@ -27,5 +41,25 @@ const i18n = createI18n<[MessageSchema], SupportedLocale>({
     pt
   }
 })
+
+export const getUiLanguage = (): SupportedLocale => {
+  const loc = (i18n.global.locale as any).value ?? (i18n.global.locale as any)
+  return (loc as SupportedLocale) || initialLocale
+}
+
+export const setUiLanguage = (locale: SupportedLocale): void => {
+  if (supportedLocales.includes(locale)) {
+    if (typeof (i18n.global.locale as any).value !== 'undefined') {
+      ;(i18n.global.locale as any).value = locale
+    } else {
+      ;(i18n.global.locale as any) = locale
+    }
+    try {
+      localStorage.setItem(STORAGE_KEY_UI_LANG, locale)
+    } catch {
+      // ignore
+    }
+  }
+}
 
 export default i18n


### PR DESCRIPTION
This pull request introduces enhanced support for exporting and importing full application configuration, including UI language and default format, and improves language persistence and switching throughout the app. The changes also update the layout of the branch list for better responsiveness.

Configuration import/export improvements:
* Added `exportConfiguration()` to `FormatManager`, enabling export of a complete configuration object (including version, UI language, default format, and all formats) instead of just custom formats. The export and import logic now handles the full configuration, including restoring UI language and default format on import. (`src/core/FormatManager.ts`, `src/components/AppConfigurationView.vue`, `src/core/__tests__/FormatManager.spec.ts`) [[1]](diffhunk://#diff-dd7e3188268481af1aaf69fd5737f65675cfa8be2ee71d734d4917fb1980488aR165-R243) [[2]](diffhunk://#diff-63862a3fb56185a297df6ae84ead244997fb3bba61b1a35d6bfb292ee1d96387L144-R144) [[3]](diffhunk://#diff-e0a457646998b72b84cfe35301f988771baa963d56bc343a196fa1038e0c97baR82-R131)
* The import logic is more robust: it supports both old array-only and new object-based configuration formats, applies language and default format settings, and merges predefined language overrides if present. (`src/core/FormatManager.ts`)

UI language persistence and switching:
* UI language is now persisted in localStorage and restored on app load. Added `getUiLanguage` and `setUiLanguage` helpers, and updated the i18n initialization logic to use stored or browser locale. (`src/i18n/index.ts`) [[1]](diffhunk://#diff-8a518b6807c2692686b085051a2455e70aacd2bb6e1e228c3389fdec04226417L11-R29) [[2]](diffhunk://#diff-8a518b6807c2692686b085051a2455e70aacd2bb6e1e228c3389fdec04226417R45-R64)
* The language selector now uses the new `setUiLanguage` function, ensuring language changes are properly handled and persisted. (`src/components/AppHeader.vue`) [[1]](diffhunk://#diff-48a13218eddf71a4d586f609c49c2d7cb6460f6ff001b5fbb4b0f395b85d8f93R4) [[2]](diffhunk://#diff-48a13218eddf71a4d586f609c49c2d7cb6460f6ff001b5fbb4b0f395b85d8f93R15-R18) [[3]](diffhunk://#diff-48a13218eddf71a4d586f609c49c2d7cb6460f6ff001b5fbb4b0f395b85d8f93L26-R31)

UI layout improvements:
* Updated the `.branch_list` style for better mobile and desktop responsiveness, setting a max width and centering the content. (`src/components/BranchList.vue`)